### PR TITLE
chore/Add .vs to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules/
 .vscode/
 .DS_Store
+.vs


### PR DESCRIPTION
Added .vs to .gitignore to support Visual Studio for markdown editing.

Fixes #14 