### PR TITLE
Fix stranded links

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,4 +4,6 @@ title: "API Reference"
 
 # Introduction
 
-This is an API reference to the various Ark Ecosystem codebases. (https://github.com/ArkEcosystem/docs).
+This is an API reference to the various Ark Ecosystem codebases. 
+
+[docs GitHub repository](https://github.com/ArkEcosystem/docs)

--- a/docs/api/sdk/cryptography/guidelines.md
+++ b/docs/api/sdk/cryptography/guidelines.md
@@ -136,7 +136,7 @@ Following these guidelines is required to provide a streamlined experience acros
 
 The structure outline here should be followed as closely as possible. If you work with an **Object Oriented Programming Language** you should be able to implement this structure as is, small adjustments might be required for languages like Go as nested packages can get hacky.
 
-You can check https://github.com/ArkEcosystem/php-crypto for an example of how this structure looks like when implemented and how it is reflected in the structure of tests.
+You can check [https://github.com/ArkEcosystem/php-crypto](https://github.com/ArkEcosystem/php-crypto) for an example of how this structure looks like when implemented and how it is reflected in the structure of tests.
 
 ```
 [src | lib | crypto]

--- a/docs/cookbook/usage-guides/how-to-use-ark-desktop-wallet.md
+++ b/docs/cookbook/usage-guides/how-to-use-ark-desktop-wallet.md
@@ -354,7 +354,7 @@ ____
 
 You can view the current price each Ark is trading for on your homescreen, it will be displayed as your set currency rate. Price changes are also provided by 1 hour, 24 hour, and 7 days % change increments.
 
-The price is retrieved from <https://coinmarketcap.com/>
+The price is retrieved from [CoinMarketCap](https://coinmarketcap.com/)
 
 ![Price](./assets/how-to-use-the-desktop-wallet/Price.png)
 

--- a/docs/faq/voting-delegates.md
+++ b/docs/faq/voting-delegates.md
@@ -11,9 +11,9 @@ title: "Voting & Delegates"
 
 The best places to find delegate information are:
 
-[Reddit](https://www.reddit.com/r/ArkDelegates/)
-[Ark forum](https://forum.ark.io/category/5/delegates)
-[arkdelegates.io](https://arkdelegates.io/)
+- [Reddit](https://www.reddit.com/r/ArkDelegates/)
+- [Ark forum](https://forum.ark.io/category/5/delegates)
+- [arkdelegates.io](https://arkdelegates.io/)
 
 ## Is voting a risk for my wallet?
 

--- a/docs/faq/voting-delegates.md
+++ b/docs/faq/voting-delegates.md
@@ -11,9 +11,9 @@ title: "Voting & Delegates"
 
 The best places to find delegate information are:
 
-https://www.reddit.com/r/ArkDelegates/
-https://forum.ark.io/category/5/delegates
-https://arkdelegates.io/
+[Reddit](https://www.reddit.com/r/ArkDelegates/)
+[Ark forum](https://forum.ark.io/category/5/delegates)
+[arkdelegates.io](https://arkdelegates.io/)
 
 ## Is voting a risk for my wallet?
 

--- a/docs/guidebook/contribution-guidelines/project-structuring.md
+++ b/docs/guidebook/contribution-guidelines/project-structuring.md
@@ -10,7 +10,7 @@ While the following guidelines are not an absolute requirement, writing your cod
 
 ### Dependencies
 
-Make sure that all dependencies you use are maintainted and receive new releases on a regular basis. Also try to use https://www.npmjs.com/package/npm-check-updates every now and then to check for outdated dependencies in your package.
+Make sure that all dependencies you use are maintainted and receive new releases on a regular basis. Also try to use [npm-check-updates](https://www.npmjs.com/package/npm-check-updates) every now and then to check for outdated dependencies in your package.
 
 ### Directory Structure
 

--- a/docs/guidebook/core/json-rpc.md
+++ b/docs/guidebook/core/json-rpc.md
@@ -46,4 +46,4 @@ If you do want to allow access from all remotes, set `allowRemote` to `true` in 
 
 ## Security
 
-If you discover a security vulnerability within this package, please send an e-mail to security@ark.io. All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within this package, please send an e-mail to [security@ark.io](mailto:security@ark.io). All security vulnerabilities will be promptly addressed.

--- a/docs/guidebook/core/json-rpc.md
+++ b/docs/guidebook/core/json-rpc.md
@@ -46,4 +46,4 @@ If you do want to allow access from all remotes, set `allowRemote` to `true` in 
 
 ## Security
 
-If you discover a security vulnerability within this package, please send an e-mail to [security@ark.io](mailto:security@ark.io). All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within this package, please send an e-mail to <security@ark.io>. All security vulnerabilities will be promptly addressed.

--- a/docs/guidebook/guides/core-commander.md
+++ b/docs/guidebook/guides/core-commander.md
@@ -21,7 +21,7 @@ bash ARKcommander.sh
 
 ## Security
 
-If you discover a security vulnerability within this package, please send an e-mail to security@ark.io. All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within this package, please send an e-mail to [security@ark.io](mailto:security@ark.io). All security vulnerabilities will be promptly addressed.
 
 ## Credits
 

--- a/docs/guidebook/guides/core-commander.md
+++ b/docs/guidebook/guides/core-commander.md
@@ -21,7 +21,7 @@ bash ARKcommander.sh
 
 ## Security
 
-If you discover a security vulnerability within this package, please send an e-mail to [security@ark.io](mailto:security@ark.io). All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within this package, please send an e-mail to <security@ark.io>. All security vulnerabilities will be promptly addressed.
 
 ## Credits
 

--- a/docs/guidebook/guides/desktop.md
+++ b/docs/guidebook/guides/desktop.md
@@ -54,7 +54,7 @@ brew cask install arkclient
 * Customized backgrounds and themes for better user experience.
 * Choose between dark or light mode.
 * Isolated processes on Windows and MacOSX to prevent from data sniffing or injection.
-* Translations (thanks to the ARK community) - help out http://osjc1wl.oneskyapp.com/collaboration/project?id=95031
+* Translations (thanks to the ARK community) - help out on [our OneSky project](http://osjc1wl.oneskyapp.com/collaboration/project?id=95031)
 * Organise your accounts with virtual folders (for instance savings, personnal etc...) so you don't pay any transfer fee (stored locally).
 * Change your delegate vote.
 * When new version is available, message is shown in the right upper part.

--- a/docs/guidebook/guides/desktop.md
+++ b/docs/guidebook/guides/desktop.md
@@ -17,7 +17,7 @@ Since we are working on the next-gen version of the wallet, we won't be reviewin
 Please do not submit Pull-Requests (PRs) unless they solve an urgent problem.
 
 ## Pinned: Help us with translations
-Collaborate with other translators on our OneSky project and help us get wallet translated in other languages  http://osjc1wl.oneskyapp.com/collaboration/project?id=95031
+Collaborate with other translators on [our OneSky project](http://osjc1wl.oneskyapp.com/collaboration/project?id=95031) and help us get wallet translated in other languages.
 
 Please do not submit Pull-Requests (PRs) for translations, but use the link above!
 

--- a/docs/guidebook/guides/explorer.md
+++ b/docs/guidebook/guides/explorer.md
@@ -122,7 +122,7 @@ $ yarn test
 
 ## 7. Security
 
-If you discover a security vulnerability within this package, please send an e-mail to security@ark.io. All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within this package, please send an e-mail to [security@ark.io](mailto:security@ark.io). All security vulnerabilities will be promptly addressed.
 
 ## 8. Contributing
 

--- a/docs/guidebook/guides/explorer.md
+++ b/docs/guidebook/guides/explorer.md
@@ -122,7 +122,7 @@ $ yarn test
 
 ## 7. Security
 
-If you discover a security vulnerability within this package, please send an e-mail to [security@ark.io](mailto:security@ark.io). All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within this package, please send an e-mail to <security@ark.io>. All security vulnerabilities will be promptly addressed.
 
 ## 8. Contributing
 

--- a/docs/introduction/ark/what-is-an-ark-address.md
+++ b/docs/introduction/ark/what-is-an-ark-address.md
@@ -111,4 +111,4 @@ Choosing 12 words randomly from the [2048 words](https://github.com/bitcoin/bips
 **5 271 537 971 301 488 476 000 309 317 528 200 000 000 combinations**
 
 #### References
-1. WebSite GlobalSign, https://www.globalsign.com/en/ssl-information-center/what-is-public-key-cryptography/
+1. [WebSite GlobalSign](https://www.globalsign.com/en/ssl-information-center/what-is-public-key-cryptography/)


### PR DESCRIPTION
Found a bunch of links which have no identifier, just plain links.

Also, found a few mentions of security@ark.io without the <> tags which automatically mailto: 's it.

Stuff here is very straight forward.