### PR TITLE
fix: update headings to maintain correct list of contents

### DIFF
--- a/docs/api/public/v1/delegates.md
+++ b/docs/api/public/v1/delegates.md
@@ -6,13 +6,13 @@ title: Public Delegates API
 
 ## List all delegates
 
-## Endpoint
+### Endpoint
 
 ```
 GET /api/delegates
 ```
 
-## Query Parameters
+### Query Parameters
 
 | Name    | Type | Description                                       | Required |
 |---------|:----:|---------------------------------------------------|:--------:|
@@ -20,7 +20,7 @@ GET /api/delegates
 | limit   | int  | The number of resources per page.                 | :x:      |
 | orderBy | int  | The column by which the resources will be sorted. | :x:      |
 
-## Response
+### Response
 
 ```json
 {
@@ -36,7 +36,7 @@ GET /api/delegates
 }
 ```
 
-## Example
+### Example
 
 <request-example>
 ```bash


### PR DESCRIPTION
Currently the menu is shown like this: 

![schermafbeelding 2018-09-07 om 21 56 32](https://user-images.githubusercontent.com/35610748/45240425-ed686a00-b2e8-11e8-8e05-0df3381392e3.png)

It contains some of the subheadings too, as they have the incorrect amount of `#`