### PR TITLE
fix first README spacing issue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ The counterpart to the Guidebook, the Cookbook contains practical code snippets 
 [*Deployer*](/cookbook/deployer/) is the place to go for code snippets and tutorials related to building your own blockchain. We cover setting up your blockchain and deploying it to major cloud hosting service providers.
 [*Exchanges*](/cookbook/exchanges/) is where developers for cryptocurrency exchanges can find information on how to integrate the ARK coin into their platforms. Though we cannot make any guarantees about the codebases of any projects besides the ARK coin, this recipe should serve as a good starting point for integrating ARK bridgechain coins as well.
 
-### [ARK API](/api/)
+### [Ark API](/api/)
 
 This section describes the structure of all ARK APIs, as well as usage examples. After you've read the Guidebook and Cookbook, this section should be the first place you turn to find out how to interact with the Ark Ecosystem software.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,8 +58,11 @@ The [*SDK*](/api/sdk/) section includes information on how to use any of the ARK
   - Swift
   - Laravel
   - Symfony
+
 [*P2P*](/api/p2p/) outlines the functions available to the P2P API.
+
 [*JSON-RPC*](/api/json-rpc/) contains instructions on how to use the JSON-RPC API to interact with the ARK blockchain. This technology is of particular interest to exchanges looking to use a Bitcoin RPC-like interface to integrate ARK into their platform.
+
 [*Webhooks*](/api/webhooks/) describes how to use the webhooks feature of Ark v2 to "listen" to events on the ARK blockchain. This is especially useful for developers who are looking to drive action in their applications in response to specific blockchain events (transactions, vote, etc.)
 
 ### [FAQ](/faq/)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

There is no newline on the front-facing readme in the ARK API section, leading to poorly rendered bottom of the section.

++ use of ARK API instead of Ark API

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [x] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:
## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're re here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation
<!--
## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->