### PR TITLE
refactor: add table of content to top-level READMEs

### DIFF
--- a/docs/.vuepress/sidebars/guidebook.js
+++ b/docs/.vuepress/sidebars/guidebook.js
@@ -35,7 +35,7 @@ module.exports = [
     ]
   },
   {
-    title: "Guides",
+    title: "Developer Guides",
     collapsable: false,
     children: [
       "/guidebook/guides/",

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,4 +6,12 @@ title: "API Reference"
 
 This is an API reference to the various Ark Ecosystem codebases. 
 
+Use the sidebar to navigate this section, or follow the links below:
+
+* [Public API](/api/public/)
+* [SDK](/api/sdk/)
+* [JSON-RPC](/api/json-rpc/)
+* [P2P](/api/p2p/)
+* [Webhooks](/api/webhooks/)
+
 [docs GitHub repository](https://github.com/ArkEcosystem/docs)

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -4,4 +4,14 @@ title: "Cookbook"
 
 # Introduction
 
-This is the cookbook for all Ark Ecosystem tutorials, code snippets, etc. [open an issue](https://github.com/ArkEcosystem/docs).
+This is the cookbook for all Ark Ecosystem tutorials, code snippets, etc. 
+
+
+Use the sidebar to navigate this section, or follow the links below:
+
+* [Usage Guides](/cookbook/usage-guides/)
+* [Node](/cookbook/node/)
+* [Deployer](/cookbook/deployer/)
+* [Exchanges](/cookbook/exchanges/)
+
+[open an issue](https://github.com/ArkEcosystem/docs).

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -6,4 +6,12 @@ title: "FAQ"
 
 This is the FAQ section.
 
+Use the sidebar to navigate this section, or follow the links below:
+
+* [Passphrases](/faq/passphrases/)
+* [Desktop Wallet](/faq/desktop-wallet/)
+* [Voting & Delegates](/faq/voting-delegates/)
+* [Bounties](/faq/bounties/)
+* [Roadmap & Updates](/faq/roadmap-updates/)
+
 [open an issue](https://github.com/ArkEcosystem/docs).

--- a/docs/guidebook/README.md
+++ b/docs/guidebook/README.md
@@ -5,3 +5,9 @@ title: "Guidebook"
 # Guidebook
 
 This is the Ark Ecosystem Developer Guidebook. After reading this, you'll be ready to build your own Ark-powered applications and blockchains -- perhaps with the help of some code from our Cookbook.
+
+Use the sidebar to navigate this section, or follow the links below:
+
+* [ARK Core](/guidebook/core/)
+* [Contribution Guidelines](/guidebooks/contribution-guidelines/)
+* [Developer Guides](/guidebook/guides/)

--- a/docs/guidebook/guides/README.md
+++ b/docs/guidebook/guides/README.md
@@ -1,8 +1,8 @@
 ---
-title: Intro to Contribution Guides
+title: Developer Guides
 ---
 
-# Intro to Contribution Guides
+# Developer Guides
 
 These guides are designed to help you get started with developing for many of our most widely-used packages. 
 

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -6,4 +6,9 @@ title: "From Blockchain to ARK"
 
 No idea what a blockchain is? Wondering what cryptocurrencies are and why your nephew won't stop talking about them? Or perhaps you've got some questions about what sets ARK apart from other blockchains? You've come to the right place -- **From Blockchain to Ark** covers it all.
 
+Use the sidebar to navigate this section, or follow the links below:
+
+* [Intro to Blockchain](/introduction/blockchain)
+* [Intro to Ark](/introduction/ark/)
+
  [open an issue](https://github.com/ArkEcosystem/docs).

--- a/docs/other/README.md
+++ b/docs/other/README.md
@@ -1,7 +1,0 @@
----
-title: "Glossary"
----
-
-# Glossary
-
-This describes resources that are useful for developers. If you have any problems or requests please [open an issue](https://github.com/ArkEcosystem/docs).


### PR DESCRIPTION
## Proposed changes
Added Table of Contents to top-level docs pages. Still need to add ToCs to lower-level pages -- will do so sometime next week.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Docs (documentation only changes)


## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation
<!--

