### PR TITLE
fix(api): specify webhooks PUT parameters as body, not query

### DIFF
--- a/docs/api/webhooks/README.md
+++ b/docs/api/webhooks/README.md
@@ -146,7 +146,7 @@ PUT /api/webhooks/{id}
 |------|:------:|----------------------------------------------|:------------------:|
 | id   | string | The identifier of the webhook to be updated. | :white_check_mark: |
 
-### Query Parameters
+### Body Parameters
 
 | Name       | Type   | Description                                             | Required |
 |------------|:------:|---------------------------------------------------------|:--------:|


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Parameters to update a webhook must be provided in the body of the request, not as HTTP query parameters. (See [the API handler](https://github.com/ArkEcosystem/core/blob/develop/packages/core-webhooks/lib/server/handler.js) for reference.) This PR reconciles this.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Docs (documentation only changes)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're re here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

