### PR TITLE
docs: properly require the elixir crypto package

### DIFF
--- a/docs/api/sdk/cryptography/elixir.md
+++ b/docs/api/sdk/cryptography/elixir.md
@@ -12,7 +12,7 @@ The package can be installed by adding `arkecosystem_crypto` to your list of dep
 
 ```elixir
 def deps do
-  [{:arkecosystem_crypto, "~> 0.1.0"}]
+  {:arkecosystem_crypto, "~> 0.1.0"}
 end
 ```
 


### PR DESCRIPTION
Mix was complaining about that while trying to install the package, so removed the [] around ` {:arkecosystem_crypto, "~> 0.1.0"} `

## Proposed changes
Mix was complaining about that while trying to install the package, so removed the [] around ` {:arkecosystem_crypto, "~> 0.1.0"} `

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines