### PR TITLE
docs: Fixed typo in go client docs

### DIFF
--- a/docs/api/sdk/clients/go.md
+++ b/docs/api/sdk/clients/go.md
@@ -159,7 +159,7 @@ func main() {
 func main() {
 	// ...
 	query := &two.Pagination{Limit: 10}
-	responseStruct, _, _ := client.Delegates.List(context.Background(), query)
+	responseStruct, _, _ := client.Node.Status(context.Background())
 
 	spew.Dump(responseStruct)
 }
@@ -202,7 +202,7 @@ func main() {
 ... > }})
 ```
 
-### Signatures - V1 
+### Signatures - V1
 
 ```go
 func main() {


### PR DESCRIPTION
## Proposed changes

Fixed typo in the go client docs in the Node section.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines