### PR TITLE
docs: document API version prefixes

### DIFF
--- a/docs/api/public/v2/README.md
+++ b/docs/api/public/v2/README.md
@@ -5,7 +5,7 @@ title: "Public API 2.0"
 # Public API 2.0: Introduction
 
 ::: warning
-All HTTP requests have to be send with the `Content-Type: application/json` header. If the header is not present it will result in malformed responses or request rejections.
+All HTTP requests have to be sent with the `Content-Type: application/json` header. If the header is not present it will result in malformed responses or request rejections.
 :::
 
 This describes the resources that make up the official Public API v2. If you have any problems or requests please [open an issue](https://github.com/ArkEcosystem/core/issues/new/choose).

--- a/docs/api/public/v2/README.md
+++ b/docs/api/public/v2/README.md
@@ -14,6 +14,12 @@ This describes the resources that make up the official Public API v2. If you hav
 
 By default, all requests to a relay receive the v1 version of the Public API. We encourage you to explicitly request this version via the `API-Version` header.
 
+You can also set the API version by adding the `v2` prefix:
+
+```
+GET /api/v2/blocks
+```
+
 ## Pagination
 
 Requests that return multiple items will be paginated to 100 items by default. You can specify further pages with the `?page` parameter. For some resources, you can also set a custom page size up to 100 with the `?limit` parameter. Note that for technical reasons not all endpoints respect the `?limit` parameter.


### PR DESCRIPTION
## Proposed changes
This solves https://github.com/ArkEcosystem/docs/issues/154.

It also adds that it's possible to set the API version by using the `v2` prefix on the URL.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation
