### PR TITLE
docs: add public testing relay to v2 API page, document version prefixes

### DIFF
--- a/docs/api/public/v2/README.md
+++ b/docs/api/public/v2/README.md
@@ -26,6 +26,4 @@ Requests that return multiple items will be paginated to 100 items by default. Y
 
 ## Public Testing Relay
 
-::: tip
-Currently there is no public relay available for the Public API v2 as it currently is under development.
-:::
+If you are not running a relay yourself you can use [https://node1.arknet.cloud/api/v2/](https://node1.arknet.cloud/api/v2/) to test API calls. Happy developing!

--- a/docs/api/public/versions.md
+++ b/docs/api/public/versions.md
@@ -8,6 +8,12 @@ There are two stable versions of the Public API: the Public API v1 and the Publi
 
 When using the Public API v1, we encourage you to request v1 via the `API-Version: 1` header. Similarly, use `API-Version: 2` to request API v2.
 
-## Deprecated versions
+## Current version
 
-- We removed support for API v1 on June 14, 2018.
+By default, all requests to a relay receive the v1 version of the Public API. We encourage you to explicitly request this version via the `API-Version` header.
+
+You can also set the API version by adding the `v2` prefix:
+
+```
+GET /api/v2/blocks
+```


### PR DESCRIPTION
## Proposed changes

- Removed `We removed support for API v1 on June 14, 2018` and added that it's possible to use the v2 API by using the `/api/v2/` prefix.

- Added `https://node1.arknet.cloud/api/v2/` for the public test relay on the v2 API page. 

## Types of changes

- [x] Docs (documentation only changes)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're re here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
