### PR TITLE
docs: fix documentation sdk url

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ The counterpart to the Guidebook, the Cookbook contains practical code snippets 
 This section describes the structure of all Ark APIs, as well as usage examples. After you've read the Guidebook and Cookbook, this section should be the first place you turn to find out how to interact with the Ark Ecosystem software.
 
 [*Public API*](/api/public/) describes the API that's accessible through any Ark node. API references for Ark v1 and v2 are included.
-The [*SDK*](/api/sdk/) section includes information on how to use any of the Ark API wrappers we've written for supercharged development in your language of choice. Currently, the following SDKs are available:
+The [*SDK*](/sdk/) section includes information on how to use any of the Ark API wrappers we've written for supercharged development in your language of choice. Currently, the following SDKs are available:
   - C++
   - .NET
   - Elixir

--- a/docs/exchanges/relay.md
+++ b/docs/exchanges/relay.md
@@ -151,6 +151,6 @@ Now that the relay node is setup you can head over to the [JSON-RPC installation
 
 ## Notes
 
-Please read the documentation pages for all of our [Ark Client and Crypto libraries](/api/sdk/) (offerred in many programming languages).
+Please read the documentation pages for all of our [Ark Client and Crypto libraries](/sdk/) (offerred in many programming languages).
 
 Also, read the [API documentation](/api/public/v2/).


### PR DESCRIPTION
## Proposed changes

`/api/sdk` was changed to `/sdk`, this PR fixes the URL.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're re here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
