### PR TITLE
docs: set correct swift-crypto sdk version

### DIFF
--- a/docs/sdk/cryptography/swift.md
+++ b/docs/sdk/cryptography/swift.md
@@ -20,7 +20,7 @@ title: "Swift"
 You can use it to integrate the Ark Swift Crypto in your project, by adding it to your `Podfile` as follows:
 
 ```
-pod 'SwiftCrypto', :git => 'https://github.com/ArkEcosystem/swift-crypto.git', :tag => '1.0.0'
+pod 'SwiftCrypto', :git => 'https://github.com/ArkEcosystem/swift-crypto.git', :tag => '0.1.0'
 ```
 
 Afterwards, install it by running `pod install`.


### PR DESCRIPTION
## Proposed changes

Since it was tagged as `0.1.0` by mr @faustbrian , the docs should also refer to that version

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation
