### PR TITLE
docs: add missing authors to desktop wallet

### DIFF
--- a/docs/guidebook/guides/desktop.md
+++ b/docs/guidebook/guides/desktop.md
@@ -83,10 +83,12 @@ Making changes to Vue Components will hot-reload that component only; getting fe
 * Join to our [gitter](https://gitter.im/ark-developers/Lobby)
 
 ## Authors
- - Oleg Shcherbyna <Oleg@ark.io>
+ - Alex Barnsley <Alex@ARK.io>
+ - ItsANameToo <itsanametoo@protonmail.com>
  - Juan Martín <Juan@ARK.io>
  - Lúcio Rubens <Lucio@ARK.io>
- - Alex Barnsley <Alex@ARK.io>
+ - Oleg Shcherbyna <Oleg@ark.io>
+ - Mario Vega <Mario@ark.io>
  - [Various Community Contributors](https://github.com/ArkEcosystem/desktop-wallet/graphs/contributors)
 
 ## License


### PR DESCRIPTION
## Proposed changes

Only some of the desktop wallet creators were listed, so this PR adds the missing ones. Also changes the order to alphabetical to match the readme in the desktop wallet repo.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation
