### PR TITLE
fix: broken link to event-emitter getEvents method

### DIFF
--- a/docs/guidebook/core/plugins/core-event-emitter.md
+++ b/docs/guidebook/core/plugins/core-event-emitter.md
@@ -34,7 +34,7 @@ Conceptually, this feature is similar to the [Hooks implementation in WordPress]
 
 Another way to think of the Event API is in the context of a [publish-subscribe pattern](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern). In this pattern, Ark Core packages can act both as publishers and subscribers of events. 
 
-The list of events published by Ark Core packages can be found in `core-blockchain`'s `getEvents` [method](https://github.com/ArkEcosystem/core/blob/develop/packages/core-blockchain/lib/blockchain.js#L638):
+The list of events published by Ark Core packages can be found in `core-blockchain`'s `getEvents` [method](https://github.com/ArkEcosystem/core/blob/develop/packages/core-blockchain/src/blockchain.ts#L664-L689):
 
 ```js
 getEvents() {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Fix broken link to list of emitted events. 
Issue introduced by typescript migration in core project. 

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [x] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're re here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

