### PR TITLE
fix: update the instructions to use Docker in Core

### DIFF
--- a/docs/guidebook/core/docker.md
+++ b/docs/guidebook/core/docker.md
@@ -36,16 +36,10 @@ Ark Core include several `Dockerfile` and `docker-compose.yml` templates to ease
 For instance, you could use this command:
 
 ```bash
-yarn docker ''
-# or
-yarn docker mytoken
+yarn docker ark
 ```
 
 This command creates a new directory (`docker`) that contains 1 folder per network.
-
-::: tip
-As a security precaution, we recommend you build the containers yourself.
-:::
 
 ## Containerize the Persistent Store
 

--- a/docs/guidebook/core/docker.md
+++ b/docs/guidebook/core/docker.md
@@ -29,7 +29,23 @@ Orchestrators with Docker as a first class citizen:
 - [Nomad](https://www.nomadproject.io/)
 - [Mesos](http://mesos.apache.org/)
 
-Ark Core provides Dockerfiles to ease development. We recommend you build the containers yourself as a security precaution.
+## Generate the Configurations
+
+Ark Core include several `Dockerfile` and `docker-compose.yml` templates to ease development. They can be used to generate different configurations, depending on the network and token.
+
+For instance, you could use this command:
+
+```bash
+yarn docker ''
+# or
+yarn docker mytoken
+```
+
+This command creates a new directory (`docker`) that contains 1 folder per network.
+
+::: tip
+As a security precaution, we recommend you build the containers yourself.
+:::
 
 ## Containerize the Persistent Store
 


### PR DESCRIPTION
## Proposed changes
Core has had some changes and now it's necessary to generate the `Dockerfile` and `docker-compose.yml` files.

## Types of changes
- [x] Docs (documentation only changes)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation