### PR TITLE
docs: move older rate limit docs to archive, update existing to 2.1

### DIFF
--- a/docs/.vuepress/sidebars/archive.js
+++ b/docs/.vuepress/sidebars/archive.js
@@ -15,5 +15,13 @@ module.exports = [
             ["/archive/api/public-v1/transactions", "Transactions"],
         ]
     },
+    {
+        title: "Exchanges",
+        collapsable: true,
+        children: [
+              ["/archive/exchanges/", "Introduction"],
+              ["/archive/exchanges/rate-limiting.md", "v2.0: Rate Limits"]
+          ]
+      },
   ]
 

--- a/docs/archive/exchanges/README.md
+++ b/docs/archive/exchanges/README.md
@@ -1,0 +1,3 @@
+# Introduction
+
+Here we organize older documentation targetted at exchanges. Prior to `v2.0`, exchange targetted documentation was quite limited, thus most of what is found here originates from the migration from `v2.0` to `v2.1`.

--- a/docs/archive/exchanges/rate-limiting.md
+++ b/docs/archive/exchanges/rate-limiting.md
@@ -8,26 +8,26 @@ By default, rate limits are enabled on Ark Core nodes. When the rate limit is ex
 
 ## Configuring the Rate Limit
 
-The default way to configure the node's rate limit is by editing the .env file found at `~/.ark/.env`. Two keys interest us here:
+The default way to configure the node's rate limit is by editing the .env file found at `~/.config/ark-core/{network}/.env`. Two keys interest us here:
 
-#### file: ~/.ark/.env
+#### file: ~/.config/ark-core/{network}/.env
 
 ```json
-CORE_RATE_LIMIT=true
-CORE_API_RATE_LIMIT_USER_LIMIT=300
+API_RATE_LIMIT=true
+ARK_API_RATE_LIMIT_USER_LIMIT=300
 ```
 
-Setting `API_RATE_LIMIT` to false will globally disable all rate limits. For internal use this is secure. More fine-grained control may be exerted by using `CORE_API_RATE_LIMIT_USER_LIMIT`, which uses IP addresses to assign rate limits. The unit is `requests/minute`.
+Setting `API_RATE_LIMIT` to false will globally disable all rate limits. For internal use this is secure. More fine-grained control may be exerted by using `ARK_API_RATE_LIMIT_USER_LIMIT`, which uses IP addresses to assign rate limits. The unit is `requests/minute`.
 
 ## Configuration through a Plugin
 
-Lower access to the rate limiting can be obtained by writing a plugin/ We can define custom behavior and [monkey patch](https://en.wikipedia.org/wiki/Monkey_patch) the Ark Core rate limiter.
+Lower access to the rate limiting can be obtained by writing a plugin at `~/.config/ark-core/{network}/plugin.js`. We can define custom behavior and [monkey patch](https://en.wikipedia.org/wiki/Monkey_patch) the Ark Core rate limiter.
 
 ```js
 @arkecosystem/core-api: {
-    enabled: !process.env.CORE_API_ENABLED,
-    host: process.env.CORE_API_HOST || '0.0.0.0',
-    port: process.env.CORE_API_PORT || 4003,
+    enabled: !process.env.ARK_API_ENABLED,
+    host: process.env.ARK_API_HOST || '0.0.0.0',
+    port: process.env.ARK_API_PORT || 4003,
     whitelist: ['*'],
     cache: {
         generateTimeout: true,
@@ -45,11 +45,11 @@ Ark Core uses the [hapi](https://hapijs.com/) framework for its API internals an
 
 ```js
 rateLimit: {
-    enabled: !process.env.CORE_API_RATE_LIMIT,
+    enabled: !process.env.ARK_API_RATE_LIMIT,
     pathLimit: false, // or set it to an integer.
-    userLimit: process.env.CORE_API_RATE_LIMIT_USER_LIMIT || 300,
+    userLimit: process.env.ARK_API_RATE_LIMIT_USER_LIMIT || 300,
     userCache: {
-      expiresIn: process.env.CORE_API_RATE_LIMIT_USER_EXPIRES || 60000,
+      expiresIn: process.env.ARK_API_RATE_LIMIT_USER_EXPIRES || 60000,
     },
     ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
   },


### PR DESCRIPTION
Rate limit documentation was still written for 2.0, moved that to the archive and updated existing rate-limiting docs to reflect variable name changes etc.
