### PR TITLE
docs: remove v1 code from clients

### DIFF
--- a/docs/releases/v2.1/migrating_2.0_2.1.md
+++ b/docs/releases/v2.1/migrating_2.0_2.1.md
@@ -18,7 +18,7 @@ It is recommended to start your relay and forger through the [Core Commander](ht
 
 After upgrading you should check whether your application still works as expected and no plugins are broken. See the following notes on which changes to consider when upgrading from one version to another.
 
-## Instructions
+## Upgrade Steps
 
 ### Upgrade Script
 

--- a/docs/releases/v2.2/migrating_2.1_2.2.md
+++ b/docs/releases/v2.2/migrating_2.1_2.2.md
@@ -10,7 +10,25 @@ Upgrading a complex software project always comes at the risk of breaking someth
 
 After upgrading you should check whether your application still works as expected and no plugins are broken. See the following notes on which changes to consider when upgrading from one version to another.
 
-## Instructions
+## Prerequisites
+
+### Configuration
+
+- Since 2.2 we no longer ship `@arkecosystem/core-graphql` by default, open the `~/.config/ark-core/<network>/plugins.js` file, locate the `@arkecosystem/core-graphql` plugin and remove the whole block.
+
+```js
+{
+    "@arkecosystem/core-graphql": {
+        // ...
+    }
+}
+```
+
+## Upgrade Steps
+
+::: warning
+Be sure to complete all of the mentioned changes in the `Prerequisites` section before you continue to upgrade to the latest version.
+:::
 
 ### Removing v2.1
 
@@ -32,18 +50,4 @@ ark relay:start
 
 ```bash
 ark forger:start
-```
-
-### Changes
-
-#### Configuration
-
-- Since 2.2 we no longer ship `@arkecosystem/core-graphql` by default, open the `~/.config/ark-core/<network>/plugins.js` file, locate the `@arkecosystem/core-graphql` plugin and remove the whole block.
-
-```js
-{
-    "@arkecosystem/core-graphql": {
-        // ...
-    }
-}
 ```

--- a/docs/sdk/clients/usage.md
+++ b/docs/sdk/clients/usage.md
@@ -38,7 +38,7 @@ $ yarn add @arkecosystem/client
 
 #### Java Installation
 
-Java may be installed from [Oracle](https://www.java.com/en/download/help/download_options.xml) or from [OpenJDK](https://openjdk.java.net/). Recently licensing on Oracle's hosted Java installation changed, so we recommend using OpenJDK.  
+Java may be installed from [Oracle](https://www.java.com/en/download/help/download_options.xml) or from [OpenJDK](https://openjdk.java.net/). Recently licensing on Oracle's hosted Java installation changed, so we recommend using OpenJDK.
 
 #### Gradle
 
@@ -88,9 +88,9 @@ paket add ArkEcosystem.Client --version 0.2.1
 
 #### PHP Installation
 
-Documentation can be found [here](http://php.net/manual/fr/install.php).
+Documentation can be found [here](http://php.net/manual/en/install.php).
 
-Others solutions like [LAMP](https://www.digitalocean.com/community/tutorials/how-to-install-linux-apache-mysql-php-lamp-stack-ubuntu-18-04), [WAMP](http://www.wampserver.com/) or [MAMP](https://www.mamp.info/en/) are available
+Others solutions like [LAMP](https://www.digitalocean.com/community/tutorials/how-to-install-linux-apache-mysql-php-lamp-stack-ubuntu-18-04), [WAMP](http://www.wampserver.com/) or [MAMP](https://www.mamp.info/en/) are available.
 
 #### Composer
 
@@ -106,7 +106,7 @@ composer require arkecosystem/client
 
 Python can be downloaded [here](https://www.python.org/downloads/).
 
-For further information on how to install Python on your operating system : 
+For further information on how to install Python on your operating system :
 
 [Windows guide](https://docs.python.org/3/using/windows.html)
 
@@ -160,7 +160,7 @@ cmake --build .
 
 Download and install the Arduino IDE (>=1.8.5) from [arduino.cc](https://www.arduino.cc/en/Main/Software)
 
-Using the Arduino IDE's built-in Library Manager, install the Ark-Cpp-Client library.  
+Using the Arduino IDE's built-in Library Manager, install the Ark-Cpp-Client library.
 Be sure to install the "-arduino" version of Cpp-Client.
 
 #### Using with the Arduino IDE
@@ -370,7 +370,7 @@ $ composer install
 5) Dependencies are now installed, you can now run the tests to see if everything is running as it should.
 
 ```bash
-$ phpunit tests/
+$ phpunit
 ```
 
 :::
@@ -736,7 +736,7 @@ An example `Connection` that connects to a node, would be created as follows:
 
 ```swift
 // Mind the '/api' after the URL, no trailing '/'!
-let conn = Connection(host: "http://0.0.0.0:4003/api") 
+let conn = Connection(host: "http://0.0.0.0:4003/api")
 ```
 
 :::
@@ -1241,7 +1241,7 @@ You may query for:
 
 - All peers through the paginated API.
 - Obtain a specific peer by IP address.
-  
+
 :::: tabs
 
 ::: tab javascript
@@ -1640,12 +1640,12 @@ iex> ArkEcosystem.Client.API.Two.Votes.list(client)
 
 ## Wallets
 
-The [wallet resource](/api/public/v2/wallets.html#list-all-wallets) provides access to: 
+The [wallet resource](/api/public/v2/wallets.html#list-all-wallets) provides access to:
 
-- Accounts.
-- Incoming and outgoing transactions per account.
-- Each account's votes.
-  
+- Wallets.
+- Incoming and outgoing transactions per wallet.
+- Each wallet's votes.
+
 :::: tabs
 
 ::: tab javascript

--- a/docs/sdk/cryptography/usage.md
+++ b/docs/sdk/cryptography/usage.md
@@ -38,7 +38,7 @@ $ yarn add @arkecosystem/crypto
 
 #### Java Installation
 
-Java may be installed from [Oracle](https://www.java.com/en/download/help/download_options.xml) or from [OpenJDK](https://openjdk.java.net/). Recently licensing on Oracle's hosted Java installation changed, so we recommend using OpenJDK.  
+Java may be installed from [Oracle](https://www.java.com/en/download/help/download_options.xml) or from [OpenJDK](https://openjdk.java.net/). Recently licensing on Oracle's hosted Java installation changed, so we recommend using OpenJDK.
 
 #### Gradle
 
@@ -88,7 +88,7 @@ paket add ArkEcosystem.Crypto --version 0.2.1
 
 #### PHP Installation
 
-Documentation can be found [here](http://php.net/manual/fr/install.php).
+Documentation can be found [here](http://php.net/manual/en/install.php).
 
 Others solutions like [LAMP](https://www.digitalocean.com/community/tutorials/how-to-install-linux-apache-mysql-php-lamp-stack-ubuntu-18-04), [WAMP](http://www.wampserver.com/) or [MAMP](https://www.mamp.info/en/) are available.
 
@@ -160,7 +160,7 @@ cmake --build .
 
 Download and install the Arduino IDE (>=1.8.5) from [arduino.cc](https://www.arduino.cc/en/Main/Software)
 
-Using the Arduino IDE's built-in Library Manager, install the Ark-Cpp-Crypto library.  
+Using the Arduino IDE's built-in Library Manager, install the Ark-Cpp-Crypto library.
 Be sure to install the "-arduino" version of Cpp-Crypto.
 
 ##### Dependencies

--- a/docs/sdk/examples/sdk-demos.md
+++ b/docs/sdk/examples/sdk-demos.md
@@ -474,7 +474,7 @@ func main() {
     url, _ := url.Parse("http://my.ark.node.ip:port/api/")
     connection.BaseURL = url
 
-    
+
     // Find a block at height 939627
     responseStructBlock, _, _ := connection.Blocks.Get(context.Background(), 939627)
 
@@ -488,7 +488,7 @@ func main() {
             *transaction,
         },
     }
-    
+
     // Send the transaction
     connection.Transactions.Create(context.Background(), body)
 }

--- a/docs/sdk/frameworks/laravel.md
+++ b/docs/sdk/frameworks/laravel.md
@@ -11,7 +11,7 @@ title: "Laravel"
 Require this package, with [Composer](https://getcomposer.org/), in the root directory of your project.
 
 ```bash
-composer require arkecosystem/laravel php-http/guzzle6-adapter
+composer require arkecosystem/laravel
 ```
 
 ## Configuration
@@ -54,7 +54,7 @@ Here you can see an example of just how simple this package is to use. Out of th
 // You can alias this in config/app.php.
 use ArkEcosystem\Ark\Facades\Ark;
 
-Ark::api('Account')->accounts();
+Ark::api('Wallets')->wallets();
 // We're done here - how easy was that, it just works!
 ```
 
@@ -64,13 +64,13 @@ The Ark manager will behave like it is an `ArkEcosystem\Ark\Client`. If you want
 use ArkEcosystem\Ark\Facades\Ark;
 
 // Writing this…
-Ark::connection('main')->api('Account')->accounts()->create($params);
+Ark::connection('main')->api('Wallets')->all();
 
 // …is identical to writing this
-Ark::api('Account')->accounts()->create($params);
+Ark::api('Wallets')->all();
 
 // and is also identical to writing this.
-Ark::connection()->api('Account')->accounts()->create($params);
+Ark::connection()->api('Wallets')->all();
 
 // This is because the main connection is configured to be the default.
 Ark::getDefaultConnection(); // This will return main.
@@ -95,7 +95,7 @@ class Foo
 
     public function bar($params)
     {
-        $this->ark->api('Account')->accounts();
+        $this->ark->api('Wallets')->all();
     }
 }
 

--- a/docs/sdk/frameworks/symfony.md
+++ b/docs/sdk/frameworks/symfony.md
@@ -58,9 +58,9 @@ class CoolStuffController extends Controller
      */
     public function index()
     {
-        $peers = $this->container->get('ark.client')->api('Peer')->peers();
+        $wallets = $this->container->get('ark.client')->api('Wallets')->all();
 
-        return new Response($peers['peers']);
+        return new Response($wallets);
     }
 }
 ```


### PR DESCRIPTION
## Proposed changes

Client docs were showing methods that no longer exist in the stable release of clients.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation