### PR TITLE
docs(guidebook): add troubleshooting for an unknown core state via CLI

### DIFF
--- a/docs/guidebook/core/cli.md
+++ b/docs/guidebook/core/cli.md
@@ -72,6 +72,10 @@ If the processes fail to start or restart after an update it is most likely an i
 
 If this doesn't resolve the issue you should run `pm2 delete all && ark relay:start && pm2 logs`, also `ark forger:start` if you are a delegate.
 
+### Process has entered an unknown state
+
+If you are receiving a message to the effect of `The "..." process has entered an unknown state.` your pm2 instance is not responding properly. This is usually resolved by a simple `pm2 update`, if that doesn't help try `pm2 kill` to destroy the pm2 daemon so it gets restarted the next time an application tries to access it.
+
 ## Available Commands
 
 ### autocomplete

--- a/docs/guidebook/core/testing.md
+++ b/docs/guidebook/core/testing.md
@@ -369,7 +369,25 @@ expect({
 }).toBeValidBlock();
 ```
 
-#### Core _(generally not useful outside of core itself)_
+#### Peers
+
+##### toBeValidArrayOfPeers()
+
+Assert that the given value is an array containing peers.
+
+```ts
+expect([{ ip: "", port: "" }]).toBeValidArrayOfPeers();
+```
+
+##### toBeValidPeer()
+
+Assert that the given value is a valid peer.
+
+```ts
+expect({ ip: "", port: "" }).toBeValidPeer();
+```
+
+#### Core API
 
 ##### toBeApiTransaction()
 
@@ -433,24 +451,6 @@ expect({
         },
     },
 }).toBeSuccessfulResponse();
-```
-
-#### Peers
-
-##### toBeValidArrayOfPeers()
-
-Assert that the given value is an array containing peers.
-
-```ts
-expect([{ ip: "", port: "" }]).toBeValidArrayOfPeers();
-```
-
-##### toBeValidPeer()
-
-Assert that the given value is a valid peer.
-
-```ts
-expect({ ip: "", port: "" }).toBeValidPeer();
 ```
 
 ### Contact us


### PR DESCRIPTION
## Proposed changes

Add a troubleshooting section for the `The "..." process has entered an unknown state.` message.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines