### PR TITLE
docs(guidebook): remove reference to yarn start command

### DIFF
--- a/docs/guidebook/core/development.md
+++ b/docs/guidebook/core/development.md
@@ -76,7 +76,6 @@ For development, you could use our ready-to-use [Docker Compose](https://docs.do
 
 If you want to start a node which consists of a `relay` and `forger` you can use any of the following commands (inside `packages/core`).
 
-- `yarn start` => `~/.ark`
 - `yarn start:mainnet` => `packages/core/bin/config/networks/mainnet`
 - `yarn start:devnet` => `packages/core/bin/config/networks/devnet`
 - `yarn start:testnet` => `packages/core/bin/config/networks/testnet`


### PR DESCRIPTION
## Proposed changes
The documentation mentions an outdated `yarn start` command  in the Development page. 
Closes #326 

## Types of changes
Remove this line from the doc : 
```
- `yarn start` => `~/.ark`
```

- [x] Docs (documentation only changes)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
- [x] I have added necessary documentation