### PR TITLE
Extend the API blocks page

### DIFF
--- a/docs/api/public/v2/README.md
+++ b/docs/api/public/v2/README.md
@@ -26,4 +26,4 @@ Requests that return multiple items will be paginated to 100 items by default. Y
 
 ## Public Testing Relay
 
-If you are not running a relay yourself you can use [https://api.ark.io/api/v2/](https://api.ark.io/api/v2/) to test API calls. Happy developing!
+If you are not running a relay yourself you can use [https://api.ark.io/api/](https://api.ark.io/api/) to test API calls. Happy developing!

--- a/docs/api/public/v2/blocks.md
+++ b/docs/api/public/v2/blocks.md
@@ -10,7 +10,7 @@ All state changes to the blockchain are in the form of blocks; they contain a se
 
 ## List all blocks
 
-The Public API may be used to query for blocks. This dataset contains billions of blocks; thus for analytical purposes, we recommend you use the [Elasticsearch](/guidebook/core/plugins/core-elasticsearch.md) plugin or query the database directly.
+The Public API may be used to query for blocks. This dataset contains millions of blocks; thus for analytical purposes, we recommend you use the [Elasticsearch](/guidebook/core/plugins/optional/core-elasticsearch.md) plugin or query the database directly.
 
 ### Endpoint
 
@@ -25,28 +25,32 @@ GET /api/blocks
 | page   | int    | The number of the page that will be returned. | :x:      |
 | limit  | int    | The number of resources per page.             | :x:      |
 | id     | string | The identifier of the block to be retrieved.  | :x:      |
-| height | int    | The identifier of the block to be retrieved.  | :x:      |
+| height | int    | The height of the block to be retrieved.      | :x:      |
 
-### Response
+### Examples
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/blocks?limit=2
+```
 
 ```json
 {
     "meta": {
         "count": 2,
-        "pageCount": 1517682,
-        "totalCount": 3035363,
-        "next": "/v2/blocks?limit=2&page=2",
+        "pageCount": 3927594,
+        "totalCount": 7855187,
+        "next": "/api/v2/blocks?limit=2&page=2",
         "previous": null,
-        "self": "/v2/blocks?limit=2&page=1",
-        "first": "/v2/blocks?limit=2&page=1",
-        "last": "/v2/blocks?limit=2&page=1517682"
+        "self": "/api/v2/blocks?limit=2&page=1",
+        "first": "/api/v2/blocks?limit=2&page=1",
+        "last": "/api/v2/blocks?limit=2&page=3927594"
     },
     "data": [
         {
-            "id": "6402736103893238690",
+            "id": "10598610037719670879",
             "version": 0,
-            "height": 3035363,
-            "previous": "58328125061111756",
+            "height": 7813396,
+            "previous": "8441333128785068929",
             "forged": {
                 "reward": 200000000,
                 "fee": 0,
@@ -58,16 +62,93 @@ GET /api/blocks
                 "length": 0
             },
             "generator": {
-                "username": "shawmishrak",
-                "address": "D7P41dV7s259L3P7BVPNyqExqNDC7vdfx9",
-                "publicKey": "030fa94238eb63db0247a9bd6a3fd810f690b449ee9ce4eb654b94b22875a9a612"
+                "username": "arkworld",
+                "address": "AeaqhUKfBtVqNhtMct3piBiWfdhbRwbg4W",
+                "publicKey": "0257581c82d1931c4b0b2df9d658ecd303fcf2a6ea4ec291669ed06f44fb75c8fe"
             },
-            "signature": "304402204d0dbeb4e71a99a0f128a3480350014f0a9f250818dae908edd15bce99f49be00220257bf240c5d8578e9ffe144e7dbf0c2259d34e6571e6a83402edc01daec6228e",
+            "signature": "30450221009ae77d6b1c3c0e1a7efa488b2f1448f0ec1160650d836014cb739a645586f42902207e426224159252497b335e57da65c1352a6164a897bec350ad175eedf55d779a",
             "transactions": 0,
             "timestamp": {
-                "epoch": 32816552,
-                "unix": 1522917752,
-                "human": "2018-04-05T08:42:32Z"
+                "epoch": 63574994,
+                "unix": 1553676194,
+                "human": "2019-03-27T08:43:14.000Z"
+            }
+        },
+        {
+            "id": "8441333128785068929",
+            "version": 0,
+            "height": 7813395,
+            "previous": "7893686533852805129",
+            "forged": {
+                "reward": 200000000,
+                "fee": 0,
+                "total": 200000000,
+                "amount": 0
+            },
+            "payload": {
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "length": 0
+            },
+            "generator": {
+                "username": "bioly",
+                "address": "AbUdMhk96FbzxH7vDYAwdyqUELmLopZV5x",
+                "publicKey": "02c0b645f19ab304d25aae3add139edd9f6ca9fd0d98e57a808100de0e93832181"
+            },
+            "signature": "3045022100ae93480145a56c3122a93d92c5504635a3cd86eead21bb6b75501b6e370e734c0220490ef1518ed4d70469868621bc41f33c0031953643ac64bde28e7dc4b55bf2ff",
+            "transactions": 0,
+            "timestamp": {
+                "epoch": 63574986,
+                "unix": 1553676186,
+                "human": "2019-03-27T08:43:06.000Z"
+            }
+        }
+    ]
+}
+```
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/blocks?height=7000042
+```
+
+```json
+{
+    "meta": {
+        "count": 1,
+        "pageCount": 1,
+        "totalCount": 1,
+        "next": null,
+        "previous": null,
+        "self": "/api/v2/blocks?height=7000042&page=1&limit=100",
+        "first": "/api/v2/blocks?height=7000042&page=1&limit=100",
+        "last": "/api/v2/blocks?height=7000042&page=1&limit=100"
+    },
+    "data": [
+        {
+            "id": "15447090855222023348",
+            "version": 0,
+            "height": 7000042,
+            "previous": "2176620005503475756",
+            "forged": {
+                "reward": 200000000,
+                "fee": 0,
+                "total": 200000000,
+                "amount": 0
+            },
+            "payload": {
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "length": 0
+            },
+            "generator": {
+                "username": "arkworld",
+                "address": "AeaqhUKfBtVqNhtMct3piBiWfdhbRwbg4W",
+                "publicKey": "0257581c82d1931c4b0b2df9d658ecd303fcf2a6ea4ec291669ed06f44fb75c8fe"
+            },
+            "signature": "3045022100f564e103c7474d2f7af5782544664f7188a5aa4e7c5829a63b15a2094a9480ae022049d18c5455dddcb5838fcac42be2d55f870ff18dd17aee3cab643f067544fcdd",
+            "transactions": 0,
+            "timestamp": {
+                "epoch": 57039818,
+                "unix": 1547141018,
+                "human": "2019-01-10T17:23:38.000Z"
             }
         }
     ]
@@ -76,7 +157,7 @@ GET /api/blocks
 
 ## Retrieve a block
 
-Blocks may be retrieved by ID (height). The height is an incremental integer.
+Blocks may be retrieved by ID or by height. The height is an incremental integer.
 
 *When comparing the order of transactions and blocks, prefer using the `block.height` over transaction timestamps, as the height is guaranteed to be correctly ordered.*
 
@@ -88,19 +169,27 @@ GET /api/blocks/{id|height}
 
 ### Path Parameters
 
-| Name | Type   | Description                                            | Required           |
-|------|:------:|--------------------------------------------------------|:------------------:|
-| id   | string | The identifier or height of the block to be retrieved. | :white_check_mark: |
+| Name         | Type   | Description                                            | Required           |
+|--------------|:------:|--------------------------------------------------------|:------------------:|
+| {id\|height} | string | The ID or height of the block to be retrieved.         | :white_check_mark: |
 
-### Response
+### Examples
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/blocks/15447090855222023348
+```
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/blocks/7000042
+```
 
 ```json
 {
     "data": {
-        "id": "58328125061111756",
+        "id": "15447090855222023348",
         "version": 0,
-        "height": 3035362,
-        "previous": "3741191868092856237",
+        "height": 7000042,
+        "previous": "2176620005503475756",
         "forged": {
             "reward": 200000000,
             "fee": 0,
@@ -112,36 +201,36 @@ GET /api/blocks/{id|height}
             "length": 0
         },
         "generator": {
-            "username": "genesis_6",
-            "address": "D5e2FzTPqdEHridjzpFZCCVyepAu6Vpmk4",
-            "publicKey": "023e577a7b3362e0aba70e6911d230e86d729b4cb640f0e0b25637b812a3e38b53"
+            "username": "arkworld",
+            "address": "AeaqhUKfBtVqNhtMct3piBiWfdhbRwbg4W",
+            "publicKey": "0257581c82d1931c4b0b2df9d658ecd303fcf2a6ea4ec291669ed06f44fb75c8fe"
         },
-        "signature": "3044022047aeb0c9cfbb5709aba4c177009bfdc7804ef597073fb9ca6cb614d7e3d1af2d02207234119d02ca26600ece045c59266945081b4c8237370576aaad7c61a09fe0ad",
+        "signature": "3045022100f564e103c7474d2f7af5782544664f7188a5aa4e7c5829a63b15a2094a9480ae022049d18c5455dddcb5838fcac42be2d55f870ff18dd17aee3cab643f067544fcdd",
         "transactions": 0,
         "timestamp": {
-            "epoch": 32816544,
-            "unix": 1522917744,
-            "human": "2018-04-05T08:42:24Z"
+            "epoch": 57039818,
+            "unix": 1547141018,
+            "human": "2019-01-10T17:23:38.000Z"
         }
     }
 }
 ```
 
-## List all transactions of a block
+## List all transactions in a block
 
 Instead of deserializing the block's payload; you can also obtain the transactions of each block as proper transaction objects directly.
 
 ### Endpoint
 
 ```
-GET /api/blocks/{id}/transactions
+GET /api/blocks/{id|height}/transactions
 ```
 
 ### Path Parameters
 
-| Name | Type   | Description                                  | Required           |
-|------|:------:|----------------------------------------------|:------------------:|
-| id   | string | The identifier of the block to be retrieved. | :white_check_mark: |
+| Name         | Type   | Description                                  | Required           |
+|--------------|:------:|----------------------------------------------|:------------------:|
+| {id\|height} | string | The identifier of the block to be retrieved. | :white_check_mark: |
 
 ### Query Parameters
 
@@ -150,36 +239,59 @@ GET /api/blocks/{id}/transactions
 | page  | int  | The number of the page that will be returned. | :x:      |
 | limit | int  | The number of resources per page.             | :x:      |
 
-### Response
+### Examples
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/blocks/12079944220667996670/transactions
+```
 
 ```json
 {
     "meta": {
-        "count": 1,
+        "count": 2,
         "pageCount": 1,
-        "totalCount": 1,
+        "totalCount": 2,
         "next": null,
         "previous": null,
-        "self": "/v2/blocks/14126007750611341900/transactions?page=1",
-        "first": "/v2/blocks/14126007750611341900/transactions?page=1",
-        "last": "/v2/blocks/14126007750611341900/transactions?page=1"
+        "self": "/api/v2/blocks/12079944220667996670/transactions?page=1&limit=100",
+        "first": "/api/v2/blocks/12079944220667996670/transactions?page=1&limit=100",
+        "last": "/api/v2/blocks/12079944220667996670/transactions?page=1&limit=100"
     },
     "data": [
         {
-            "id": "57415c61e6e7f10a6f9820d5124b3916f3c3a036b360f4802f0eb484f86f3369",
-            "blockId": "14126007750611341900",
+            "id": "7ce77a3520250b3e8174786835cf61b5f62db436949bf46952ed0e17fd8f903d",
+            "blockId": "12079944220667996670",
+            "version": 1,
             "type": 0,
-            "amount": 1000000000000000,
-            "fee": 10000000,
-            "sender": "DGihocTkwDygiFvmg6aG8jThYTic47GzU9",
-            "recipient": "DRac35wghMcmUSe5jDMLBDLWkVVjyKZFxK",
-            "signature": "3045022100878335a71ab6769f3c1e2895041ad24d6c58cdcfe1151c639e65289e5287b0a8022010800bcfdc3223a9c59a6b014e8adf72f1c34df8a46afe655b021930b03e214e",
-            "vendorField": "yo",
-            "confirmations": 3034848,
+            "amount": 100059429,
+            "fee": 816000,
+            "sender": "AKATy581uXWrbm8B4DTQh4R9RbqaWRiKRY",
+            "recipient": "AKp7Bu9Nzpq3idcatrLmjsS76E6WkZ2Q2a",
+            "signature": "3045022100f9af677be546ec1645fe16f057bff7e06d9410ada259960d1e89fd9cc940221a022052023db0f829d13e43f614a1dab9b07559faa15e2e571494eaf9cf93813ea7f1",
+            "signSignature": "3044022067d039dcda866eb89803c9c649308db755aec1d2f7d0894436c6a06511033daf0220348a50856be0902066f8686a78c667cf5c64c504124ed1576d8aa8b029649700",
+            "vendorField": "Payout from arkmoon",
+            "confirmations": 356,
             "timestamp": {
-                "epoch": 3909196,
-                "unix": 1494010396,
-                "human": "2017-05-05T18:53:16Z"
+                "epoch": 63573682,
+                "unix": 1553674882,
+                "human": "2019-03-27T08:21:22.000Z"
+            }
+        },
+        {
+            "id": "da7b05c6a2787a7744345378d614eaad503543daba422c80fc6b929f8be61a91",
+            "blockId": "12079944220667996670",
+            "version": 1,
+            "type": 0,
+            "amount": 188600000,
+            "fee": 10000000,
+            "sender": "AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK",
+            "recipient": "AFvsCDPsYYUSSqmnAT7bomdAwPrdq7vDHp",
+            "signature": "30440220438bb7293731cbfb62e2229590b64bc9858879d47a34caf88b29eed7761864fc022042fb49ceb25ba7982cbdde6cf544a20a893ceed2378be0564c3405e52cd33d11",
+            "confirmations": 356,
+            "timestamp": {
+                "epoch": 63573682,
+                "unix": 1553674882,
+                "human": "2019-03-27T08:21:22.000Z"
             }
         }
     ]
@@ -188,7 +300,7 @@ GET /api/blocks/{id}/transactions
 
 ## Search all blocks
 
-It is possible to filter for specifics blocks using the search resource. Filtering for blocks Node side is a lot more efficient than requesting a large payload and filtering client side.
+It is possible to filter for specifics blocks using the search resource. Filtering for blocks at the Node side is a lot more efficient than requesting a large payload and filtering it at the client side.
 
 ### Endpoint
 
@@ -205,66 +317,109 @@ POST /api/blocks/search
 
 ### Body Parameters
 
-| Name                      | Type   | Description  | Required |
-|---------------------------|:------:|--------------|:--------:|
-| id                        | string | ...          | :x:      |
-| version                   | int    | ...          | :x:      |
-| previousBlock             | int    | ...          | :x:      |
-| payloadHash               | string | ...          | :x:      |
-| generatorPublicKey        | string | ...          | :x:      |
-| blockSignature            | string | ...          | :x:      |
-| timestamp                 | object | ...          | :x:      |
-| timestamp.from            | int    | ...          | :x:      |
-| timestamp.to              | int    | ...          | :x:      |
-| height                    | object | ...          | :x:      |
-| height.from               | int    | ...          | :x:      |
-| height.to                 | int    | ...          | :x:      |
-| numberOfTransactions      | object | ...          | :x:      |
-| numberOfTransactions.from | int    | ...          | :x:      |
-| numberOfTransactions.to   | int    | ...          | :x:      |
-| totalAmount               | object | ...          | :x:      |
-| totalAmount.from          | int    | ...          | :x:      |
-| totalAmount.to            | int    | ...          | :x:      |
-| totalFee                  | object | ...          | :x:      |
-| totalFee.from             | int    | ...          | :x:      |
-| totalFee.to               | int    | ...          | :x:      |
-| reward                    | object | ...          | :x:      |
-| reward.from               | int    | ...          | :x:      |
-| reward.to                 | int    | ...          | :x:      |
-| payloadLength             | object | ...          | :x:      |
-| payloadLength.from        | int    | ...          | :x:      |
-| payloadLength.to          | int    | ...          | :x:      |
+| Name                      | Type   | Description                                                                                                                      | Required |
+|---------------------------|:------:|----------------------------------------------------------------------------------------------------------------------------------|:--------:|
+| id                        | string | ID of the block.                                                                                                                 | :x:      |
+| version                   | int    | Version of the block.                                                                                                            | :x:      |
+| previousBlock             | int    | ID of the previous block.                                                                                                        | :x:      |
+| payloadHash               | string | Hash of the payload.                                                                                                             | :x:      |
+| generatorPublicKey        | string | Public key of the forger who forged the block.                                                                                   | :x:      |
+| blockSignature            | string | Signature of the block.                                                                                                          | :x:      |
+| timestamp                 | object | Timestamp range for block creation time. Measured in number of seconds since the genesis block.                                  | :x:      |
+| timestamp.from            | int    | Block creation time must be bigger or equal to this.                                                                             | :x:      |
+| timestamp.to              | int    | Block creation time must be smaller or equal to this.                                                                            | :x:      |
+| height                    | object | Height range of the block. The genesis block has height 1.                                                                       | :x:      |
+| height.from               | int    | Block height must be bigger or equal to this.                                                                                    | :x:      |
+| height.to                 | int    | Block height must be smaller or equal to this.                                                                                   | :x:      |
+| numberOfTransactions      | object | Ranage for number of transactions contained in the block.                                                                        | :x:      |
+| numberOfTransactions.from | int    | The number of transactions in the block must be bigger or equal to this.                                                         | :x:      |
+| numberOfTransactions.to   | int    | The number of transactions in the block must be smaller or equal to this.                                                        | :x:      |
+| totalAmount               | object | Range for total amount transacted in the block, including block reward, transaction fees and transactions' amounts. In arktoshi. | :x:      |
+| totalAmount.from          | int    | Block total amount must be bigger or equal to this.                                                                              | :x:      |
+| totalAmount.to            | int    | Block total amount must be smaller or equal to this.                                                                             | :x:      |
+| totalFee                  | object | Range for the sum of all transactions' fees in the block. In arktoshi.                                                           | :x:      |
+| totalFee.from             | int    | The sum of all transactions' fees in the block must be bigger or equal to this.                                                  | :x:      |
+| totalFee.to               | int    | The sum of all transactions' fees in the block must be smaller or equal to this.                                                 | :x:      |
+| reward                    | object | Range for block reward. In arktoshi.                                                                                             | :x:      |
+| reward.from               | int    | Block reward must be bigger or equal to this.                                                                                    | :x:      |
+| reward.to                 | int    | Block reward must be smaller or equal to this.                                                                                   | :x:      |
+| payloadLength             | object | Range for block payload length. In bytes.                                                                                        | :x:      |
+| payloadLength.from        | int    | Block payload length must be bigger or equal to this.                                                                            | :x:      |
+| payloadLength.to          | int    | Block payload length must be smaller or equal to this.                                                                           | :x:      |
 
-### Response
+### Examples
+
+```sh
+curl --header "API-Version: 2" --data 'numberOfTransactions={ "from": 100, "to": 110 }' --data 'timestamp={ "from": 60000000 }' https://api.ark.io/api/blocks/search?limit=2
+```
 
 ```json
 {
     "meta": {
-        "count": 1,
-        "pageCount": 1,
-        "totalCount": 1,
-        "next": null,
+        "count": 2,
+        "pageCount": 4,
+        "totalCount": 7,
+        "next": "/api/v2/blocks/search?limit=2&page=2",
         "previous": null,
-        "self": "/v2/blocks/14126007750611341900/transactions/search?page=1",
-        "first": "/v2/blocks/14126007750611341900/transactions/search?page=1",
-        "last": "/v2/blocks/14126007750611341900/transactions/search?page=1"
+        "self": "/api/v2/blocks/search?limit=2&page=1",
+        "first": "/api/v2/blocks/search?limit=2&page=1",
+        "last": "/api/v2/blocks/search?limit=2&page=4"
     },
     "data": [
         {
-            "id": "57415c61e6e7f10a6f9820d5124b3916f3c3a036b360f4802f0eb484f86f3369",
-            "blockId": "14126007750611341900",
-            "type": 0,
-            "amount": 1000000000000000,
-            "fee": 10000000,
-            "sender": "DGihocTkwDygiFvmg6aG8jThYTic47GzU9",
-            "recipient": "DRac35wghMcmUSe5jDMLBDLWkVVjyKZFxK",
-            "signature": "3045022100878335a71ab6769f3c1e2895041ad24d6c58cdcfe1151c639e65289e5287b0a8022010800bcfdc3223a9c59a6b014e8adf72f1c34df8a46afe655b021930b03e214e",
-            "vendorField": "yo",
-            "confirmations": 3034848,
+            "id": "884117316712991715",
+            "version": 0,
+            "height": 7812000,
+            "previous": "11133306790169853761",
+            "forged": {
+                "reward": 200000000,
+                "fee": 46920000,
+                "total": 246920000,
+                "amount": 414375753
+            },
+            "payload": {
+                "hash": "65b32bc2792f1c84613027503bc4534febeadce4e45612357086a46233a2199d",
+                "length": 3264
+            },
+            "generator": {
+                "username": "geops",
+                "address": "AU1TGCYoWzBnGMyMK9GTS8BG6EFbgc5xxC",
+                "publicKey": "02bf72c578a12c35a97ca1230b93017161ee42c3f0ab82f6fe7c95b3b43561a076"
+            },
+            "signature": "3044022007082f2d025c49a1daf30f8461daf0cca0fad3a67c1e0369d9438687670fbbd5022028e9cbaadc5a33c55111cf98aad23697c4618e38fa178cc8163bf8275b41632c",
+            "transactions": 102,
             "timestamp": {
-                "epoch": 3909196,
-                "unix": 1494010396,
-                "human": "2017-05-05T18:53:16Z"
+                "epoch": 63563826,
+                "unix": 1553665026,
+                "human": "2019-03-27T05:37:06.000Z"
+            }
+        },
+        {
+            "id": "14707858435494505009",
+            "version": 0,
+            "height": 7806541,
+            "previous": "10644622929675679656",
+            "forged": {
+                "reward": 200000000,
+                "fee": 112845000,
+                "total": 312845000,
+                "amount": 296221771579
+            },
+            "payload": {
+                "hash": "9ffe089a0058c1a28f0b54643fcee66c8a8cce1c1b60253951e81170c80610ca",
+                "length": 3360
+            },
+            "generator": {
+                "username": "cams_yellow_jacket",
+                "address": "AGvhBGb4cCZnP2wUo1oCSi83LUtGDG7Y6X",
+                "publicKey": "02902de3fcb257e9248e2ae668d2e314027f0ca05c1eb21e1c5817c7580014669f"
+            },
+            "signature": "30440220715fdf928549266485e4a61bf1468d4a1fe1c6d4b9d452379ad8da742e58244b022059a9f586a2fc07521fa45bdf6dd122dc78cf594174c445648b254f4c3ef4fc29",
+            "transactions": 105,
+            "timestamp": {
+                "epoch": 63520130,
+                "unix": 1553621330,
+                "human": "2019-03-26T17:28:50.000Z"
             }
         }
     ]


### PR DESCRIPTION
* Add example curl commands to submit requests, removing any
  ambiguity on how to use the API.
* Fill missing descriptions
* s/billions/millions/ (of blocks)