### PR TITLE
chore: 2.3 to 2.4 migrate docs whitelist issue

### DIFF
--- a/docs/releases/v2.4/migrating_2.3_2.4.md
+++ b/docs/releases/v2.4/migrating_2.3_2.4.md
@@ -108,8 +108,8 @@ It's especially important to register this plugin as this is what the Desktop an
        ...
    }
    ```
-
-3. Save the changes.
+3. If you have a `whitelist` property in the `core-p2p` entry, make sure to remove this too. Starting with v2.4 this property will filter out any peers that don't match the whitelist.
+4. Save the changes.
 
 ### Step 4. Update `core-forger` Configuration
 


### PR DESCRIPTION
Adds a line to remove the `whitelist` property if it was available in the `core-p2p` config when upgrading from  2.3 to 2.4