### PR TITLE
docs(faq): change slack channel on /Bounties page

### DIFF
--- a/docs/faq/bounties.md
+++ b/docs/faq/bounties.md
@@ -14,7 +14,7 @@ The ARK development bounty program has been updated for 2019. Previous years hav
 
 More information about the **ARK Development and Security Bounty Program** can be found in the dedicated [ARK blog post](https://blog.ark.io/ark-development-and-security-bounty-program-a95122d06879).
 
-Before pushing a PR (Pull Request), please [jump in our slack #development](https://ark.io/slack) channel in order to discuss your contributions or to connect with other ARK developers.
+Before pushing a PR (Pull Request), please [jump in our slack #general](https://ark.io/slack) channel in order to discuss your contributions or to connect with other ARK developers.
 
 ::: tip
 ARKs bounty program includes all accepted PRs for [this repository](https://github.com/ArkEcosystem/docs)


### PR DESCRIPTION
This PR removes the reference to the non-existent `#development` channel and replaces it with `#general` channel. `#general` is now the preferred channel to discuss these things, according to Sam [ARK Team].

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [x] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No