### PR TITLE
docs(api): add orderBy query parameter documentation to the Public API docs

### DIFF
--- a/docs/api/public/v2/blocks.md
+++ b/docs/api/public/v2/blocks.md
@@ -20,12 +20,17 @@ GET /api/blocks
 
 ### Query Parameters
 
-| Name   | Type   | Description                                   | Required |
-| :----- | :----: | :-------------------------------------------- | :------: |
-| page   | int    | The number of the page that will be returned. | :x:      |
-| limit  | int    | The number of resources per page.             | :x:      |
-| id     | string | The identifier of the block to be retrieved.  | :x:      |
-| height | int    | The height of the block to be retrieved.      | :x:      |
+| Name    | Type   | Description                                       | Required |
+| :------ | :----: | :------------------------------------------------ | :------: |
+| page    | int    | The number of the page that will be returned.     | :x:      |
+| limit   | int    | The number of resources per page.                 | :x:      |
+| id      | string | The identifier of the block to be retrieved.      | :x:      |
+| height  | int    | The height of the block to be retrieved.          | :x:      |
+| orderBy | string | The column by which the resources will be sorted. | :x:      |
+
+::: tip
+The `orderBy` parameter on this endpoint supports the following values: *id*, *height*, *previous_block*, *payload_hash*, *generator_public_key*, *timestamp*
+:::
 
 ### Examples
 
@@ -152,6 +157,55 @@ curl --header "API-Version: 2" https://api.ark.io/api/blocks?height=7000042
                 "epoch": 57039818,
                 "unix": 1547141018,
                 "human": "2019-01-10T17:23:38.000Z"
+            }
+        }
+    ]
+}
+```
+
+```sh
+curl --header "API-Version: 2" "https://api.ark.io/api/blocks?limit=1&orderBy=height:asc"
+```
+
+```json
+{
+    "meta": {
+        "count": 1,
+        "pageCount": 8864471,
+        "totalCount": 8864471,
+        "next": "/api/v2/blocks?limit=1&orderBy=height%3Aasc&page=2",
+        "previous": null,
+        "self": "/api/v2/blocks?limit=1&orderBy=height%3Aasc&page=1",
+        "first": "/api/v2/blocks?limit=1&orderBy=height%3Aasc&page=1",
+        "last": "/api/v2/blocks?limit=1&orderBy=height%3Aasc&page=8864471"
+    },
+    "data": [
+        {
+            "id": "4366553906931540162",
+            "version": 0,
+            "height": 1,
+            "previous": null,
+            "forged": {
+                "reward": 0,
+                "fee": 0,
+                "total": 0,
+                "amount": 12500000000000004
+            },
+            "payload": {
+                "hash": "6e84d08bd299ed97c212c886c98a57e36545c8f5d645ca7eeae63a8bd62d8988",
+                "length": 313052
+            },
+            "generator": {
+                "address": "AdLb2r8XEmhNqW3CXyNGEEVZxXAfvTqPWR",
+                "publicKey": "03a4d147a417376742f9ab78c7c3891574d19376aa62e7bbddceaf12e096e79fe0"
+            },
+            "signature": "3045022100c442ef265f2a7fa102d61e9a180e335fd17e8e3224307dadf8ac856e569c5c5102201a34cb1302cf4e0887b45784bfbdaf5cfbc44f6d6dad638d56bafa82ec96fd45",
+            "confirmations": 8715645,
+            "transactions": 1492,
+            "timestamp": {
+                "epoch": 0,
+                "unix": 1490101200,
+                "human": "2017-03-21T13:00:00.000Z"
             }
         }
     ]

--- a/docs/api/public/v2/delegates.md
+++ b/docs/api/public/v2/delegates.md
@@ -22,10 +22,15 @@ GET /api/delegates
 
 ### Query Parameters
 
-| Name  | Type | Description                                   | Required |
-| :---- | :--: | :-------------------------------------------- | :------: |
-| page  | int  | The number of the page that will be returned. |   :x:    |
-| limit | int  | The number of resources per page.             |   :x:    |
+| Name    | Type   | Description                                       | Required |
+| :------ | :----: | :------------------------------------------------ | :------: |
+| page    | int    | The number of the page that will be returned.     | :x:      |
+| limit   | int    | The number of resources per page.                 | :x:      |
+| orderBy | string | The column by which the resources will be sorted. | :x:      |
+
+::: tip
+The `orderBy` parameter on this endpoint supports the following values: *username*, *rank*, *votes*
+:::
 
 ### Examples
 
@@ -149,6 +154,55 @@ curl --header "API-Version: 2" "https://api.ark.io/api/delegates?page=5&limit=2"
                 "total": 27360598159298
             }
         }
+    ]
+}
+```
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/delegates?orderBy=votes:desc
+```
+
+```json
+{
+    "meta": {
+        "count": 100,
+        "pageCount": 11,
+        "totalCount": 1038,
+        "next": "/api/v2/delegates?orderBy=votes%3Adesc&page=2&limit=100",
+        "previous": null,
+        "self": "/api/v2/delegates?orderBy=votes%3Adesc&page=1&limit=100",
+        "first": "/api/v2/delegates?orderBy=votes%3Adesc&page=1&limit=100",
+        "last": "/api/v2/delegates?orderBy=votes%3Adesc&page=11&limit=100"
+    },
+    "data": [
+        {
+            "username": "biz_classic",
+            "address": "AKdr5d9AMEnsKYxpDcoHdyyjSCKVx3r9Nj",
+            "publicKey": "020431436cf94f3c6a6ba566fe9e42678db8486590c732ca6c3803a10a86f50b92",
+            "votes": 296505542169896,
+            "rank": 1,
+            "blocks": {
+                "produced": 151063,
+                "last": {
+                    "id": "41451ba9c5af806b3b56b3c5fa60001cf26a98d33d63e4e25aeae94ca789d574",
+                    "height": 8715707,
+                    "timestamp": {
+                        "epoch": 70844000,
+                        "unix": 1560945200,
+                        "human": "2019-06-19T11:53:20.000Z"
+                    }
+                }
+            },
+            "production": {
+                "approval": 2.35
+            },
+            "forged": {
+                "fees": 1173040419815,
+                "rewards": 30212600000000,
+                "total": 31385640419815
+            }
+        },
+        ...
     ]
 }
 ```

--- a/docs/api/public/v2/peers.md
+++ b/docs/api/public/v2/peers.md
@@ -28,10 +28,14 @@ GET /api/peers
 | version | string | The node version by which the resources will be filtered.     | :x:      |
 | orderBy | string | The column by which the resources will be sorted.             | :x:      |
 
+::: tip
+The `orderBy` parameter on this endpoint supports the following value: *version*
+:::
+
 ### Examples
 
 ```sh
-curl --header "API-Version: 2" https://api.ark.io/api/peers
+curl --header "API-Version: 2" https://api.ark.io/api/peers?orderBy=version:desc
 ```
 
 ### Response
@@ -42,15 +46,15 @@ curl --header "API-Version: 2" https://api.ark.io/api/peers
         "count": 100,
         "pageCount": 2,
         "totalCount": 170,
-        "next": "/api/v2/peers?page=2&limit=100",
+        "next": "/api/v2/peers?orderBy=version%3Adesc&page=2&limit=100",
         "previous": null,
-        "self": "/api/v2/peers?page=1&limit=100",
-        "first": "/api/v2/peers?page=1&limit=100",
-        "last": "/api/v2/peers?page=2&limit=100"
+        "self": "/api/v2/peers?orderBy=version%3Adesc&page=1&limit=100",
+        "first": "/api/v2/peers?orderBy=version%3Adesc&page=1&limit=100",
+        "last": "/api/v2/peers?orderBy=version%3Adesc&page=2&limit=100"
     },
     "data": [
         {
-            "ip": "178.32.65.139",
+            "ip": "5.196.105.36",
             "port": 4001,
             "ports": {
                 "@arkecosystem/core-webhooks": -1,
@@ -59,8 +63,8 @@ curl --header "API-Version: 2" https://api.ark.io/api/peers
                 "@arkecosystem/core-api": 4003
             },
             "version": "2.4.12",
-            "height": 8691474,
-            "latency": 11
+            "height": 8716307,
+            "latency": 529
         },
         ...
     ]

--- a/docs/api/public/v2/transactions.md
+++ b/docs/api/public/v2/transactions.md
@@ -105,21 +105,24 @@ GET /api/transactions
 
 ### Query Parameters
 
-| Name    | Type | Description                                   | Required |
-| :------ | :--: | :-------------------------------------------- | :------: |
-| page    | int  | The number of the page that will be returned. |   :x:    |
-| limit   | int  | The number of resources per page.             |   :x:    |
-| type    | int  | The transaction type to be retrieved.         |   :x:    |
-| blockId | int  | The block id to be retrieved.                 |   :x:    |
-| id      | int  | The transaction id to be retrieved.           |   :x:    |
+| Name    | Type   | Description                                       | Required |
+| :------ | :----: | :------------------------------------------------ | :------: |
+| page    | int    | The number of the page that will be returned.     | :x:      |
+| limit   | int    | The number of resources per page.                 | :x:      |
+| type    | int    | The transaction type to be retrieved.             | :x:      |
+| blockId | int    | The block id to be retrieved.                     | :x:      |
+| id      | int    | The transaction id to be retrieved.               | :x:      |
+| orderBy | string | The column by which the resources will be sorted. | :x:      |
+
+::: tip
+The `orderBy` parameter on this endpoint supports the following values: *id*, *block_id*, *type*, *version*, *timestamp*, *amount*, *fee*
+:::
 
 ### Examples
 
 ```sh
 curl --header "API-Version: 2" https://api.ark.io/api/transactions?limit=1
 ```
-
-### Response
 
 ```json
 {
@@ -152,6 +155,61 @@ curl --header "API-Version: 2" https://api.ark.io/api/transactions?limit=1
                 "human": "2019-06-17T06:54:41.000Z"
             }
         }
+    ]
+}
+```
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/transactions?orderBy=fee:desc
+```
+
+```json
+{
+    "meta": {
+        "count": 100,
+        "pageCount": 26018,
+        "totalCount": 2601719,
+        "next": "/api/v2/transactions?orderBy=fee%3Adesc&page=2&limit=100",
+        "previous": null,
+        "self": "/api/v2/transactions?orderBy=fee%3Adesc&page=1&limit=100",
+        "first": "/api/v2/transactions?orderBy=fee%3Adesc&page=1&limit=100",
+        "last": "/api/v2/transactions?orderBy=fee%3Adesc&page=26018&limit=100"
+    },
+    "data": [
+        {
+            "id": "31de62ecd08b12b897d0ab50fb8cb07cff149b8cee7116c17ccb8b3916e2eeb7",
+            "blockId": "14135536682818837490",
+            "version": 1,
+            "type": 4,
+            "amount": 0,
+            "fee": 3000000000,
+            "sender": "ARSEY4zRjc4wicXgzRZmuvUcKtBrdY4zsn",
+            "senderPublicKey": "021cd9ee596d56032e7c77e3ba8c0413ff2d5539d7a36782e8187433c3b03d22bf",
+            "signature": "3045022100e714ef935c1844f3c80a6d0aa801fb3656f914951ae4616ed6780e1721d1914a02207cf0e172ecf83081c199ffa716b1082dc06838bbebeaec6b184dd81b6d22a775",
+            "signatures": [
+                "304402204d319b1172708320cf912986d4961a513470a153d373de61ff59c34565aab55802206334f13c4a7f0b035ab49504a895e380a2f0325336204d4920cb499287b62e163045022100e5da7d060c920dbb75f44e5728ef9bd78291e470525d34885c591630707db07e0220383e244823bc3073fa43a5c597ae88fbf9292b0e3ad10901cbf47ad78353b30c304402206d659e1dbfb178be171c3fde4ce4b324e607cf75b53dc5cd80e17dc8faa99bcc0220675ec782d333564071792b3df1ad60225f7dcabd4ed124d53540206b23cac7ce304402201e083e0012e2b312aa790ed09155e9dc28a55c6f88681bdcd1fd8f511fa70dd402201ba1913eb019aeea1fdb7ae2358f16e49d32d58f927f5f7bb3b76206d2b5acf530450221009435b1327df3f96caeb275533b268d056eeaf7f23da86cb9c8a531d57c3fabda02204a1e9692844c93cd583086d9e53e7249454058fc9fb05ebd839f7663ad6e3273"
+            ],
+            "asset": {
+                "multiSignatureLegacy": {
+                    "keysgroup": [
+                        "+0294e3a351e44e87be58bf8b8a15780475c8a189b9d46304fb7140c8b042904bc9",
+                        "+02b5c2c1902d06221a2752310bbdd191c6b5febce2868e673e0efb4ceafabd9ed2",
+                        "+0308156438f8ac290d27caa9f61a38c9e7c09394d254584bd9bd1d21d90605dbde",
+                        "+023fb26000436f51b045c5a0e5cd40fd28744752d9f704ba24f4b294f4d28f3ca9",
+                        "+02e9b6be0d66aa295a8c714712e7b4570030f3f6f6f480eb829488db9cab0d60fb"
+                    ],
+                    "lifetime": 72,
+                    "min": 3
+                }
+            },
+            "confirmations": 2628705,
+            "timestamp": {
+                "epoch": 49671405,
+                "unix": 1539772605,
+                "human": "2018-10-17T10:36:45.000Z"
+            }
+        },
+        ...
     ]
 }
 ```

--- a/docs/api/public/v2/votes.md
+++ b/docs/api/public/v2/votes.md
@@ -24,18 +24,21 @@ GET /api/votes
 
 ### Query Parameters
 
-| Name    | Type | Description                                   | Required |
-| :------ | :--: | :-------------------------------------------- | :------: |
-| page    | int  | The number of the page that will be returned. | :x:      |
-| limit   | int  | The number of resources per page.             | :x:      |
+| Name    | Type   | Description                                       | Required |
+| :------ | :----: | :------------------------------------------------ | :------: |
+| page    | int    | The number of the page that will be returned.     | :x:      |
+| limit   | int    | The number of resources per page.                 | :x:      |
+| orderBy | string | The column by which the resources will be sorted. | :x:      |
+
+::: tip
+The `orderBy` parameter on this endpoint supports the following values: *id*, *blockId*, *fee*, *sender*, *senderPublickey*, *recipient*, *confirmations*, *timestamp*
+:::
 
 ### Examples
 
 ```sh
 curl --header "API-Version: 2" https://api.ark.io/api/votes
 ```
-
-### Response
 
 ```json
 {
@@ -71,6 +74,51 @@ curl --header "API-Version: 2" https://api.ark.io/api/votes
                 "epoch": 70650961,
                 "unix": 1560752161,
                 "human": "2019-06-17T06:16:01.000Z"
+            }
+        },
+        ...
+    ]
+}
+```
+
+```sh
+curl --header "API-Version: 2" https://api.ark.io/api/votes?orderBy=timestamp:asc
+```
+
+```json
+{
+    "meta": {
+        "count": 100,
+        "pageCount": 289,
+        "totalCount": 28836,
+        "next": "/api/v2/votes?orderBy=timestamp%3Aasc&page=2&limit=100",
+        "previous": null,
+        "self": "/api/v2/votes?orderBy=timestamp%3Aasc&page=1&limit=100",
+        "first": "/api/v2/votes?orderBy=timestamp%3Aasc&page=1&limit=100",
+        "last": "/api/v2/votes?orderBy=timestamp%3Aasc&page=289&limit=100"
+    },
+    "data": [
+        {
+            "id": "74a064741055e14b3a4a3488e22294297c01e709c9ccb7be1e2875770bcadc9e",
+            "blockId": "7207976816638172132",
+            "version": 1,
+            "type": 3,
+            "amount": 0,
+            "fee": 100000000,
+            "sender": "ARMiT43EzxWMEtpJBjZiGvRsprMw1aBD71",
+            "senderPublicKey": "0262ed5a8d8df19e56e26bab5903d648632be034852c40c9cef672b78db8f70442",
+            "recipient": "ARMiT43EzxWMEtpJBjZiGvRsprMw1aBD71",
+            "signature": "3045022100c192b53e8eeaae6e599efc009e6cf1aa38333688350d722dc5a9e7aca8e390aa02202254ebf2f9b4103c3fb2f495a49258eab88cd92d9936c9a9830c9282a4f51949",
+            "asset": {
+                "votes": [
+                    "+0262ed5a8d8df19e56e26bab5903d648632be034852c40c9cef672b78db8f70442"
+                ]
+            },
+            "confirmations": 8715525,
+            "timestamp": {
+                "epoch": 16101,
+                "unix": 1490117301,
+                "human": "2017-03-21T17:28:21.000Z"
             }
         },
         ...

--- a/docs/api/public/v2/wallets.md
+++ b/docs/api/public/v2/wallets.md
@@ -18,18 +18,21 @@ GET /api/wallets
 
 ### Query Parameters
 
-| Name  | Type | Description                                   | Required |
-| :---- | :--: | :-------------------------------------------- | :------: |
-| page  | int  | The number of the page that will be returned. |   :x:    |
-| limit | int  | The number of resources per page.             |   :x:    |
+| Name    | Type   | Description                                       | Required |
+| :------ | :----: | :------------------------------------------------ | :------: |
+| page    | int    | The number of the page that will be returned.     | :x:      |
+| limit   | int    | The number of resources per page.                 | :x:      |
+| orderBy | string | The column by which the resources will be sorted. | :x:      |
+
+::: tip
+The `orderBy` parameter on this endpoint supports the following values: *address*, *balance*, *username*, *vote*
+:::
 
 ### Examples
 
 ```sh
 curl --header "API-Version: 2" https://api.ark.io/api/wallets
 ```
-
-### Response
 
 ```json
 {
@@ -51,6 +54,57 @@ curl --header "API-Version: 2" https://api.ark.io/api/wallets
             "isDelegate": false
         },
         ...
+    ]
+}
+```
+
+```sh
+curl --header "API-Version: 2" "https://api.ark.io/api/wallets?orderBy=balance&limit=5"
+```
+
+```json
+{
+    "meta": {
+        "count": 5,
+        "pageCount": 23733,
+        "totalCount": 118664,
+        "next": "/api/v2/wallets?orderBy=balance&limit=5&page=2",
+        "previous": null,
+        "self": "/api/v2/wallets?orderBy=balance&limit=5&page=1",
+        "first": "/api/v2/wallets?orderBy=balance&limit=5&page=1",
+        "last": "/api/v2/wallets?orderBy=balance&limit=5&page=23733"
+    },
+    "data": [
+        {
+            "address": "AUDud8tvyVZa67p3QY7XPRUTjRGnWQQ9Xv",
+            "publicKey": "021d03bace0687a1a5e797f884b13fb46f817ec32de1374a7f223f24404401d220",
+            "balance": 1969102010034762,
+            "isDelegate": false
+        },
+        {
+            "address": "AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK",
+            "publicKey": "02ff171adaef486b7db9fc160b28433d20cf43163d56fd28fee72145f0d5219a4b",
+            "balance": 1252766744221840,
+            "isDelegate": false
+        },
+        {
+            "address": "AdTyTzaXPtj1J1DzTgVksa9NYdUuXCRbm1",
+            "publicKey": "02d4c5a7206d8298ef84a79b4c21a73ad5ae460cfff964f660f517960bb834040d",
+            "balance": 875001440401317,
+            "isDelegate": false
+        },
+        {
+            "address": "AdS7WvzqusoP759qRo6HDmUz2L34u4fMHz",
+            "publicKey": "03e7635481b035149829ef74f972e69eca75363bc96e75be57579b0e6fb3f22192",
+            "balance": 686779104859574,
+            "isDelegate": false
+        },
+        {
+            "address": "Aakg29vVhQhJ5nrsAHysTUqkTBVfmgBSXU",
+            "publicKey": "0394e9f4d4eb47e8cbfda6e0d1a4082973ae178e3a60662ac84591c39d06e059f5",
+            "balance": 299230936869587,
+            "isDelegate": false
+        }
     ]
 }
 ```


### PR DESCRIPTION
Resolves #436

## Summary  
This PR adds documentation of the `orderBy` query parameter to the following Public API docs:

- Blocks
- Delegates
- Transactions
- Votes
- Wallets

## Steps taken  
The following steps have been taking for each of the API endpoints:

- Look up / find out about all sortable columns
- Test each individual column in a query
- Add `orderBy` to the query parameter table
- Add information about all sortable columns for the specific endpoint below the table (a `:::TIP :::` box has been used for this)
- Add an example curl command containing a `orderBy` parameter
- Add the example response

Some of the `### Response` lines have been removed for paragraphs with multiple Examples/Responses. This is to comply with the styling found on other pages (eg: /Blocks) 


## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [x] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No