### PR TITLE
revert: "fix: #417"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,49 +14,49 @@ Our documentation is a central hub for all knowledge ARK Ecosystem, and as such 
 
 Below you can read short summaries of each chapter and the topics you'll find within them. The documentation will be edited and expanded frequently as development continues, so check back often for updates.
 
-### [From Blockchain to ARK](/docs/introduction/)
+### [From Blockchain to ARK](/introduction/)
 
 This is our introduction to the world of blockchain and ARK's place within it.
 
-[_Blockchain_](/docs/introduction/blockchain/) is a good place to begin if you have little prior experience with blockchain. It answers many common questions about what blockchain is, why it's useful, and how ARK helps make blockchain easier.
-The [_ARK_](/docs/introduction/ark/) section highlights the philosophy behind the ARK Ecosystem blockchain, and how that compares against some of the sector's most popular projects (Bitcoin, Ethereum, etc.)
+[_Blockchain_](/introduction/blockchain/) is a good place to begin if you have little prior experience with blockchain. It answers many common questions about what blockchain is, why it's useful, and how ARK helps make blockchain easier.
+The [_ARK_](/introduction/ark/) section highlights the philosophy behind the ARK Ecosystem blockchain, and how that compares against some of the sector's most popular projects (Bitcoin, Ethereum, etc.)
 
-### [The ARK Ecosystem Guidebook](/docs/guidebook/)
+### [The ARK Ecosystem Guidebook](/guidebook/)
 
 In this section, we describe the software components of the ARK Ecosystem. We focus in particular on ARK Core: the codebase powering the nodes that, in turn, power the ARK network.
 
-[_Core_](/docs/guidebook/core/) describes the architecture of ARK Core. At present, the documentation focuses on the packages that allow for easy application and blockchain customization.
-[_Contribution Guidelines_](/docs/guidebook/contribution-guidelines/) details the process for contributing to ARK Ecosystem software. Reading this section also helps to understand the coding styles and practices that inform development across the Ecosystem.
-[_Guides_](/docs/guidebook/guides/) offers software-specific information on how to develop for ARK Ecosystem. From running your first test suite to submitting pull requests for your code's inclusion into ARK itself, this is the section to read if you're a developer looking to get involved.
+[_Core_](/guidebook/core/) describes the architecture of ARK Core. At present, the documentation focuses on the packages that allow for easy application and blockchain customization.
+[_Contribution Guidelines_](/guidebook/contribution-guidelines/) details the process for contributing to ARK Ecosystem software. Reading this section also helps to understand the coding styles and practices that inform development across the Ecosystem.
+[_Guides_](/guidebook/guides/) offers software-specific information on how to develop for ARK Ecosystem. From running your first test suite to submitting pull requests for your code's inclusion into ARK itself, this is the section to read if you're a developer looking to get involved.
 
-### [The ARK Ecosystem Tutorials](/docs/tutorials/)
+### [The ARK Ecosystem Tutorials](/tutorials/)
 
 The counterpart to the Guidebook, the tutorials contain practical code snippets and guides to help developers write productive code with the ARK Ecosystem as quickly as possible. We'll always provide context for the code we post here, so you'll have the convenience of copy-and-paste and the knowledge to strike your own path when necessary.
 
-[_Usage Guides_](/docs/tutorials/usage-guides/) describe how to use the various ARK packages, including:
+[_Usage Guides_](/tutorials/usage-guides/) describe how to use the various ARK packages, including:
 
-1. [Desktop Wallet](/docs/tutorials/usage-guides/how-to-use-ark-desktop-wallet.md)
-2. [Mobile Wallet](/docs/tutorials/usage-guides/how-to-use-ark-mobile-wallet.md)
-3. [Explorer](/docs/tutorials/usage-guides/how-to-use-ark-explorer.md)
+1. [Desktop Wallet](/tutorials/usage-guides/how-to-use-ark-desktop-wallet.html)
+2. [Mobile Wallet](/tutorials/usage-guides/how-to-use-ark-mobile-wallet.html)
+3. [Explorer](/tutorials/usage-guides/how-to-use-ark-explorer.html)
 
-[_Deployer_](/docs/tutorials/deployer/) is the place to go for code snippets and tutorials related to building your own blockchain. We cover setting up your blockchain and deploying it to major cloud hosting service providers.
-[_Exchanges_](/docs/exchanges/) is where developers for cryptocurrency exchanges can find information on how to integrate the ARK coin into their platforms. Though we cannot make any guarantees about the codebases of any projects besides the ARK coin, this recipe should serve as a good starting point for integrating ARK BridgeChain coins as well.
-[_IoT_](/docs/tutorials/iot/) provides guidance on anything from setting up your ARK IoT development environment to storing and reacting to data on the ARK blockchain using platforms like Arduino and PlatformIO.
+[_Deployer_](/tutorials/deployer/) is the place to go for code snippets and tutorials related to building your own blockchain. We cover setting up your blockchain and deploying it to major cloud hosting service providers.
+[_Exchanges_](/exchanges/) is where developers for cryptocurrency exchanges can find information on how to integrate the ARK coin into their platforms. Though we cannot make any guarantees about the codebases of any projects besides the ARK coin, this recipe should serve as a good starting point for integrating ARK BridgeChain coins as well.
+[_IoT_](/tutorials/iot/) provides guidance on anything from setting up your ARK IoT development environment to storing and reacting to data on the ARK blockchain using platforms like Arduino and PlatformIO.
 
-### [ARK Ecosystem Cryptography](/docs/cryptography/)
+### [ARK Ecosystem Cryptography](/cryptography/)
 
 This section provides details and insights into the cryptographic identities of the ARK blockchain. It covers topics such as PrivateKeys, PublicKeys, and Signatures; as well as the hashing and encoding methods used by ARK.
 
-### [ARK Ecosystem IoT (Internet of Things)](/docs/iot/)
+### [ARK Ecosystem IoT (Internet of Things)](/iot/)
 
-[_IoT (Internet of Things)_](/docs/iot/) provides an overview of what ARK IoT is, what boards are supported, and offers design considerations and general guidance on developing with ARK on IoT platforms.
+[_IoT (Internet of Things)_](/iot/) provides an overview of what ARK IoT is, what boards are supported, and offers design considerations and general guidance on developing with ARK on IoT platforms.
 
-### [ARK API](/docs/api/)
+### [ARK API](/api/)
 
 This section describes the structure of all ARK APIs, as well as usage examples. After you've read the Guidebook and tutorials, this section should be the first place you turn to find out how to interact with the ARK Ecosystem software.
 
-[_Public API_](/docs/api/public/) describes the API that's accessible through any ARK node. API references for ARK v1 and v2 are included.
-The [_SDK_](/docs/sdk/) section includes information on how to use any of the ARK API wrappers we've written for supercharged development in your language of choice. Currently, the following SDKs are available:
+[_Public API_](/api/public/) describes the API that's accessible through any ARK node. API references for ARK v1 and v2 are included.
+The [_SDK_](/sdk/) section includes information on how to use any of the ARK API wrappers we've written for supercharged development in your language of choice. Currently, the following SDKs are available:
 
 - C++
 - .NET
@@ -72,16 +72,16 @@ The [_SDK_](/docs/sdk/) section includes information on how to use any of the AR
 - Swift
 - Symfony
 
-[_P2P_](/docs/api/p2p/) outlines the functions available to the P2P API.
+[_P2P_](/api/p2p/) outlines the functions available to the P2P API.
 
-[_JSON-RPC_](/docs/api/json-rpc/) contains instructions on how to use the JSON-RPC API to interact with the ARK blockchain. This technology is of particular interest to exchanges looking to use a Bitcoin RPC-like interface to integrate ARK into their platform.
+[_JSON-RPC_](/api/json-rpc/) contains instructions on how to use the JSON-RPC API to interact with the ARK blockchain. This technology is of particular interest to exchanges looking to use a Bitcoin RPC-like interface to integrate ARK into their platform.
 
-[_Webhooks_](/docs/api/webhooks/) describes how to use the webhooks feature of ARK v2 to "listen" to events on the ARK blockchain. This is especially useful for developers who are looking to drive action in their applications in response to specific blockchain events (transactions, vote, etc.)
+[_Webhooks_](/api/webhooks/) describes how to use the webhooks feature of ARK v2 to "listen" to events on the ARK blockchain. This is especially useful for developers who are looking to drive action in their applications in response to specific blockchain events (transactions, vote, etc.)
 
-### [FAQ](/docs/faq/)
+### [FAQ](/faq/)
 
 We answer some of the most common questions about ARK Ecosystem here, from general questions about ARK philosophy to specific tips on how to resolve commonly encountered errors.
 
-### [Glossary](/docs/glossary/)
+### [Glossary](/glossary/)
 
 Basic definitions of some of the vocabulary used throughout the documentation.


### PR DESCRIPTION
While the PR fixed redirection issues on the GitHub repo; redirections on https://docs.ark.io are now messed up. 

For eg: 
Clicking on "From Blockchain to ARK" on the GitHub repo, takes you to the right page.
However, clicking on "From Blockchain to ARK" on https://docs.ark.io takes you to a 404 page.