### PR TITLE
docs(pay): add reset functionality to API documentation

### DIFF
--- a/docs/guidebook/guides/pay.md
+++ b/docs/guidebook/guides/pay.md
@@ -151,3 +151,9 @@ await gateway.start();
     port: '4003'
 }])
 ```
+
+### Stop the Listener and Reset the Configuration.
+
+```js
+.reset()
+```


### PR DESCRIPTION
This PR adds documentation of the `reset()` functionality to the API documentation of ARK Pay.

Because this info is currently missing from the docs, I had to dig in the ARK Pay to figure out on how to stop the listener. Therefore I think it would be very useful if this information would be added to the documentation, to prevent other users from running into this problem.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [x] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No