### PR TITLE
fix(cpp): correct namespace capitalization

### DIFF
--- a/docs/guidebook/developer/send-transaction.md
+++ b/docs/guidebook/developer/send-transaction.md
@@ -156,7 +156,7 @@ func main() {
 ::: tab C++
 
 ```cpp
-ARK::Client::Connection<ARK::Client::Api> connection("167.114.29.54", 4003);
+Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.54", 4003);
 ```
 
 :::
@@ -430,7 +430,7 @@ Address address = Address::fromPassphrase(passphrase, devnetByte);
 ```
 
 ````cpp
-uint64_t epoch = ARK::Crypto::Utils::Slot::epoch(ARK::Crypto::Networks::Devnet);
+uint64_t epoch = Ark::Crypto::Utils::Slot::epoch(Ark::Crypto::Networks::Devnet);
 
 //  'epoch' output: 1490101200
 :::
@@ -548,7 +548,7 @@ func main() {
 ::: tab C++
 
 ```cpp
-auto transfer = ARK::Crypto::Transactions::Builder::buildTransfer(
+auto transfer = Ark::Crypto::Transactions::Builder::buildTransfer(
     "recipientID",
     1000000000,
     "vendorfield",

--- a/docs/sdk/clients/usage.md
+++ b/docs/sdk/clients/usage.md
@@ -147,7 +147,7 @@ If you are using CMake head over to [cmake.org](https://www.cmake.org/download/)
 #### CMake
 
 ```bash
-git clone https://github.com/ARKEcosystem/cpp-client
+git clone https://github.com/ArkEcosystem/cpp-client
 cd cpp-client
 # Init & Update Micro-Ecc Submodule
 git submodule init
@@ -712,7 +712,7 @@ A `Connection` expects an IP Address and Port by which the API can be reached.
 An example Connection, that interfaces with the API of an ARK node, would be created as follows:
 
 ```cpp
-ARK::Client::Connection<ARK::Client::Api> connection("167.114.29.54", 4003);
+Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.54", 4003);
 ```
 
 :::

--- a/docs/sdk/cryptography/usage.md
+++ b/docs/sdk/cryptography/usage.md
@@ -147,7 +147,7 @@ If you are using CMake head over to [cmake.org](https://www.cmake.org/download/)
 #### Make
 
 ```bash
-git clone https://github.com/ARKEcosystem/cpp-crypto
+git clone https://github.com/ArkEcosystem/cpp-crypto
 cd cpp-crypto
 # Init & Update Micro-Ecc Submodule
 git submodule init
@@ -807,7 +807,7 @@ transaction := crypto.BuildTransfer(
 Using the Transaction builder class.
 
 ```cpp
-ARK::Crypto::Transactions::Transaction transfer = ARK::Crypto::Transactions::Builder::buildTransfer(
+Ark::Crypto::Transactions::Transaction transfer = Ark::Crypto::Transactions::Builder::buildTransfer(
     "recipientID",
     1000000000,
     "vendorfield",
@@ -818,9 +818,9 @@ ARK::Crypto::Transactions::Transaction transfer = ARK::Crypto::Transactions::Bui
 We can also do this manually.
 
 ```cpp
-  ARK::Crypto::Transactions::Transaction transaction;
-  transaction.type = ARK::Crypto::Enums::Types::TRANSFER;
-  transaction.fee = ARK::Crypto::Configuration::Fee().get(ARK::Crypto::Enums::Types::TRANSFER);
+  Ark::Crypto::Transactions::Transaction transaction;
+  transaction.type = Ark::Crypto::Enums::Types::TRANSFER;
+  transaction.fee = Ark::Crypto::Configuration::Fee().get(Ark::Crypto::Enums::Types::TRANSFER);
   transaction.recipientId = "recipientId";
   transaction.amount = 1000000000;
   transaction.vendorField = "vendorfield";
@@ -963,14 +963,14 @@ serialized := crypto.SerializeTransaction(transaction)
 ::: tab C++
 
 ```cpp
-ARK::Crypto::Transactions::Transaction transfer = ARK::Crypto::Transactions::Builder::buildTransfer(
+Ark::Crypto::Transactions::Transaction transfer = Ark::Crypto::Transactions::Builder::buildTransfer(
     "recipientID",
     1000000000,
     "vendorfield",
     "passphrase",
     "secondPassphrase");
 
-ARK::Crypto::Transactions::Serializer serializer(transfer);
+Ark::Crypto::Transactions::Serializer serializer(transfer);
 std::string serializedTransaction = serializer.serialize();
 ```
 
@@ -1085,7 +1085,7 @@ transaction := crypto.DeserializeTransaction(serialized)
 ::: tab C++
 
 ```cpp
-ARK::Crypto::Transactions::Deserializer deserializer("serialized_transaction");
+Ark::Crypto::Transactions::Deserializer deserializer("serialized_transaction");
 auto actual = deserializer.deserialize();
 ```
 
@@ -1210,7 +1210,7 @@ message, _ := crypto.SignMessage("Hello World", "top secret")
 ```cpp
 const auto text = "Computer science is no more about computers than astronomy is about telescopes.";
 const auto passphrase = "bullet parade snow bacon mutual deposit brass floor staff list concert ask";
-ARK::Crypto::Utils::Message message;
+Ark::Crypto::Utils::Message message;
 message.sign(text, passphrase);
 ```
 
@@ -1340,10 +1340,10 @@ ok, err := message.Verify()
 
 ```cpp
 const auto text = "Computer science is no more about computers than astronomy is about telescopes.";
-ARK::Crypto::Identities::PublicKey publicKey = ARK::Crypto::Identities::PublicKey::fromHex("0275776018638e5c40f1b922901e96cac2caa734585ef302b4a2801ee9a338a456");
+Ark::Crypto::Identities::PublicKey publicKey = Ark::Crypto::Identities::PublicKey::fromHex("0275776018638e5c40f1b922901e96cac2caa734585ef302b4a2801ee9a338a456");
 std::vector<uint8_t> signature = HexToBytes("3044022021704f2adb2e4a10a3ddc1d7d64552b8061c05f6d12a168c69091c75581d611402200edf37689d2786fc690af9f0f6fa1f629c95695039f648a6d455484302402e93");
 
-ARK::Crypto::Utils::Message message(
+Ark::Crypto::Utils::Message message(
     text,
     publicKey,
     signature
@@ -1486,7 +1486,7 @@ address, _ := crypto.AddressFromPassphrase("this is a top secret passphrase")
 ```cpp
 const auto passphrase = "bullet parade snow bacon mutual deposit brass floor staff list concert ask";
 const uint8_t networkVersion = 0x1E;
-ARK::Crypto::Identities::Address address = ARK::Crypto::Identities::Address::fromPassphrase(passphrase, networkVersion);
+Ark::Crypto::Identities::Address address = Ark::Crypto::Identities::Address::fromPassphrase(passphrase, networkVersion);
 ```
 
 :::
@@ -1590,9 +1590,9 @@ address := publicKey.ToAddress()
 ::: tab C++
 
 ```cpp
-ARK::Crypto::Identities::PublicKey publicKey("029fdf41a7d69d8efc7b236c21b9509a23d862ea4ed8b13a56e31eee58dbfd97b4");
+Ark::Crypto::Identities::PublicKey publicKey("029fdf41a7d69d8efc7b236c21b9509a23d862ea4ed8b13a56e31eee58dbfd97b4");
 const uint8_t networkVersion = 0x1E;
-ARK::Crypto::Identities::Address address = ARK::Crypto::Identities::Address::fromPublicKey(publicKey, networkVersion);
+Ark::Crypto::Identities::Address address = Ark::Crypto::Identities::Address::fromPublicKey(publicKey, networkVersion);
 ```
 
 :::
@@ -1700,7 +1700,7 @@ fmt.Println(privateKey.ToAddress())
 ```cpp
 PrivateKey privateKey("950981ce17df662dbc1d25305f8597a71309fb8f7232203a0944477e2534b021");
 const uint8_t networkVersion = 0x1E;
-ARK::Crypto::Identities::Address address = ARK::Crypto::Identities::Address::fromPrivateKey(privateKey, networkVersion);
+Ark::Crypto::Identities::Address address = Ark::Crypto::Identities::Address::fromPrivateKey(privateKey, networkVersion);
 ```
 
 :::
@@ -1802,9 +1802,9 @@ fmt.Println(crypto.ValidateAddress("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib"))
 ::: tab C++
 
 ```cpp
-ARK::Crypto::Identities::Address address("DStZXkgpEjxbG355nQ26vnkp95p24U9tsV");
+Ark::Crypto::Identities::Address address("DStZXkgpEjxbG355nQ26vnkp95p24U9tsV");
 const uint8_t networkVersion = 0x1E;
-bool isValid = ARK::Crypto::Identities::Address::validate(address, networkVersion);
+bool isValid = Ark::Crypto::Identities::Address::validate(address, networkVersion);
 ```
 
 :::
@@ -1914,7 +1914,7 @@ privateKey, _ := crypto.PrivateKeyFromPassphrase("this is a top secret passphras
 
 ```cpp
 const auto passphrase = "bullet parade snow bacon mutual deposit brass floor staff list concert ask";
-ARK::Crypto::Identities::PrivateKey privateKey = ARK::Crypto::Identities::PrivateKey::fromPassphrase(passphrase);
+Ark::Crypto::Identities::PrivateKey privateKey = Ark::Crypto::Identities::PrivateKey::fromPassphrase(passphrase);
 ```
 
 :::
@@ -2013,7 +2013,7 @@ privateKey, _ := crypto.PrivateKeyFromHex("d8839c2432bfd0a67ef10a804ba991eabba19
 ::: tab C++
 
 ```cpp
-ARK::Crypto::Identities::PrivateKey privateKey = ARK::Crypto::Identities::PrivateKey::fromHex("950981ce17df662dbc1d25305f8597a71309fb8f7232203a0944477e2534b021");
+Ark::Crypto::Identities::PrivateKey privateKey = Ark::Crypto::Identities::PrivateKey::fromHex("950981ce17df662dbc1d25305f8597a71309fb8f7232203a0944477e2534b021");
 ```
 
 :::
@@ -2095,7 +2095,7 @@ This function has not been implemented in this client library.
 
 ```cpp
 const char* wifStr = "SEZuJZouNK8GLXNApjciH4QnSKiNr971exVcL2Y6XfrDF5o977zB";
-ARK::Crypto::Identities::PrivateKey privateKey = ARK::Crypto::Identities::PrivateKey::fromWIFString(wifStr, wifByte);
+Ark::Crypto::Identities::PrivateKey privateKey = Ark::Crypto::Identities::PrivateKey::fromWIFString(wifStr, wifByte);
 ```
 
 :::
@@ -2188,7 +2188,7 @@ publicKey, _ := crypto.PublicKeyFromPassphrase("this is a top secret passphrase"
 
 ```cpp
 const auto passphrase = "bullet parade snow bacon mutual deposit brass floor staff list concert ask";
-ARK::Crypto::Identities::PublicKey publicKey = ARK::Crypto::Identities::PublicKey::fromPassphrase(passphrase);
+Ark::Crypto::Identities::PublicKey publicKey = Ark::Crypto::Identities::PublicKey::fromPassphrase(passphrase);
 ```
 
 :::
@@ -2280,7 +2280,7 @@ publicKey, _ := crypto.PublicKeyFromHex("034151a3ec46b5670a682b0a63394f863587d1b
 ::: tab C++
 
 ```cpp
-ARK::Crypto::Identities::PublicKey publicKey = ARK::Crypto::Identities::PublicKey::fromHex("029fdf41a7d69d8efc7b236c21b9509a23d862ea4ed8b13a56e31eee58dbfd97b4");
+Ark::Crypto::Identities::PublicKey publicKey = Ark::Crypto::Identities::PublicKey::fromHex("029fdf41a7d69d8efc7b236c21b9509a23d862ea4ed8b13a56e31eee58dbfd97b4");
 ```
 
 :::
@@ -2362,8 +2362,8 @@ This function has not been implemented in this client library.
 ::: tab C++
 
 ```cpp
-ARK::Crypto::Identities::PublicKey publicKey("029fdf41a7d69d8efc7b236c21b9509a23d862ea4ed8b13a56e31eee58dbfd97b4");
-bool isValid = ARK::Crypto::Identities::PublicKey::validate(publicKey);
+Ark::Crypto::Identities::PublicKey publicKey("029fdf41a7d69d8efc7b236c21b9509a23d862ea4ed8b13a56e31eee58dbfd97b4");
+bool isValid = Ark::Crypto::Identities::PublicKey::validate(publicKey);
 ```
 
 :::
@@ -2457,7 +2457,7 @@ privateKey, _ := crypto.PrivateKeyFromPassphrase("this is a top secret passphras
 ```cpp
 const auto passphrase = "bullet parade snow bacon mutual deposit brass floor staff list concert ask";
 const uint8_t wifByte = 0xaa;
-ARK::Crypto::Identities::WIF wif = ARK::Crypto::Identities::WIF::fromPassphrase(passphrase, wifByte);
+Ark::Crypto::Identities::WIF wif = Ark::Crypto::Identities::WIF::fromPassphrase(passphrase, wifByte);
 ```
 
 :::

--- a/docs/sdk/examples/sdk-demos.md
+++ b/docs/sdk/examples/sdk-demos.md
@@ -232,13 +232,13 @@ const char* password = "yourWiFiPassword";
 
 void doExample() {
     //  create the connection.
-    ARK::Client::Connection<ARK::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
 
     //  retrieve a specific block.
     std::string blockResponse = connection.api.blocks.get("58328125061111756");
 
     //  create transaction payload.
-    auto transfer = ARK::Crypto::Transactions::Builder::buildTransfer(
+    auto transfer = Ark::Crypto::Transactions::Builder::buildTransfer(
         "recipientID",
         1000000000,
         "vendorfield",
@@ -328,13 +328,13 @@ const char* password = "yourWiFiPassword";
 
 void doExample() {
     //  create the connection.
-    ARK::Client::Connection<ARK::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
 
     //  retrieve a specific block.
     std::string blockResponse = connection.api.blocks.get("58328125061111756");
 
     //  create transaction payload.
-    auto transfer = ARK::Crypto::Transactions::Builder::buildTransfer(
+    auto transfer = Ark::Crypto::Transactions::Builder::buildTransfer(
         "recipientID",
         1000000000,
         "vendorfield",
@@ -389,13 +389,13 @@ void loop() { };
 
 int main() {
     //  create the connection.
-    ARK::Client::Connection<ARK::Client::Api> connection("167.114.29.55", 4003);
+    Ark::Client::Connection<Ark::Client::Api> connection("167.114.29.55", 4003);
 
     //  retrieve a specific block.
     std::string blockResponse = connection.api.blocks.get("58328125061111756");
 
     //  create transaction payload.
-    auto transfer = ARK::Crypto::Transactions::Builder::buildTransfer(
+    auto transfer = Ark::Crypto::Transactions::Builder::buildTransfer(
         "recipientID",
         1000000000,
         "vendorfield",

--- a/docs/tutorials/iot/boards/esp32-adafruit/README.md
+++ b/docs/tutorials/iot/boards/esp32-adafruit/README.md
@@ -472,7 +472,7 @@ int port = 4003;
  * This is how you define a connection while speficying the API class as a 'template argument'
  * You instantiate a connection by passing a IP address as a 'c_string', and the port as an 'int'.
  */
-ARK::Client::Connection<ARK::Client::Api> connection(peer, port);
+Ark::Client::Connection<Ark::Client::Api> connection(peer, port);
 /**/
 
 /****************************************/
@@ -927,7 +927,7 @@ void checkCrypto() {
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
    * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
-    ARK::Crypto::Configuration::Fee fee;
+    Ark::Crypto::Configuration::Fee fee;
     unsigned long typeZeroTransactionFee = fee.get(0);
     Serial.print("\n Type 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.
@@ -1016,7 +1016,7 @@ void checkCrypto() {
    */
   const auto text = "Computer science is no more about computers than astronomy is about telescopes.";
   const auto passphrase5 = "viable weasel wage promote praise inflict jaguar tackle color unusual exclude direct";
-  ARK::Crypto::Utils::Message message;
+  Ark::Crypto::Utils::Message message;
   message.sign(text, passphrase5);
     Serial.print("\nSignature from Signed Message: ");
     Serial.println(BytesToHex(message.signature).c_str()); // the 'message.signature' is a byte-array. Use 'BytesToHex()' to view the output. Arduino requires a 'c_str()' to 'print'.

--- a/docs/tutorials/iot/boards/esp8266-adafruit/README.md
+++ b/docs/tutorials/iot/boards/esp8266-adafruit/README.md
@@ -403,7 +403,7 @@ int port = 4003;
  * This is how you define a connection while speficying the API class as a 'template argument'
  * You instantiate a connection by passing a IP address as a 'c_string', and the port as an 'int'.
  */
-ARK::Client::Connection<ARK::Client::Api> connection(peer, port);
+Ark::Client::Connection<Ark::Client::Api> connection(peer, port);
 /**/
 
 /****************************************/
@@ -859,7 +859,7 @@ void checkCrypto() {
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
    * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
-    ARK::Crypto::Configuration::Fee fee;
+    Ark::Crypto::Configuration::Fee fee;
     unsigned long typeZeroTransactionFee = fee.get(0);
     Serial.print("\n Type 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.

--- a/docs/tutorials/iot/environment/cpp/README.md
+++ b/docs/tutorials/iot/environment/cpp/README.md
@@ -81,7 +81,7 @@ git clone --branch arduino https://github.com/ARKEcosystem/cpp-client.git
 1). Clone the Cpp-Crypto from GitHub.
 
 ```asciidoc
-git clone --branch arduino https://github.com/ARKEcosystem/cpp-crypto.git
+git clone --branch arduino https://github.com/ArkEcosystem/cpp-crypto.git
 ```
 
 2). Copy the Cpp-Crypto folder to your Arduino "/libraries" folder.

--- a/docs/tutorials/iot/examples/arduino/client/assets/esp32.ino
+++ b/docs/tutorials/iot/examples/arduino/client/assets/esp32.ino
@@ -61,7 +61,7 @@ int port = 4003;
  * This is how you define a connection while speficying the API class as a 'template argument'
  * You instantiate a connection by passing a IP address as a 'c_string', and the port as an 'int'.
  */
-ARK::Client::Connection<ARK::Client::Api> connection(peer, port);
+Ark::Client::Connection<Ark::Client::Api> connection(peer, port);
 /**/
 
 /****************************************/

--- a/docs/tutorials/iot/examples/arduino/client/assets/esp8266.ino
+++ b/docs/tutorials/iot/examples/arduino/client/assets/esp8266.ino
@@ -61,7 +61,7 @@ int port = 4003;
  * This is how you define a connection while speficying the API class as a 'template argument'
  * You instantiate a connection by passing a IP address as a 'c_string', and the port as an 'int'.
  */
-ARK::Client::Connection<ARK::Client::Api> connection(peer, port);
+Ark::Client::Connection<Ark::Client::Api> connection(peer, port);
 /**/
 
 /****************************************/

--- a/docs/tutorials/iot/examples/arduino/client/esp32/README.md
+++ b/docs/tutorials/iot/examples/arduino/client/esp32/README.md
@@ -70,7 +70,7 @@ int port = 4003;
  * This is how you define a connection while speficying the API class as a 'template argument'
  * You instantiate a connection by passing a IP address as a 'c_string', and the port as an 'int'.
  */
-ARK::Client::Connection<ARK::Client::Api> connection(peer, port);
+Ark::Client::Connection<Ark::Client::Api> connection(peer, port);
 /**/
 
 /****************************************/

--- a/docs/tutorials/iot/examples/arduino/client/esp8266/README.md
+++ b/docs/tutorials/iot/examples/arduino/client/esp8266/README.md
@@ -70,7 +70,7 @@ int port = 4003;
  * This is how you define a connection while speficying the API class as a 'template argument'
  * You instantiate a connection by passing a IP address as a 'c_string', and the port as an 'int'.
  */
-ARK::Client::Connection<ARK::Client::Api> connection(peer, port);
+Ark::Client::Connection<Ark::Client::Api> connection(peer, port);
 /**/
 
 /****************************************/

--- a/docs/tutorials/iot/examples/arduino/crypto/assets/esp32.ino
+++ b/docs/tutorials/iot/examples/arduino/crypto/assets/esp32.ino
@@ -35,7 +35,7 @@ void checkCrypto() {
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
    * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
-    ARK::Crypto::Configuration::Fee fee;
+    Ark::Crypto::Configuration::Fee fee;
     unsigned long typeZeroTransactionFee = fee.get(0);
     Serial.print("\n Type 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.
@@ -124,7 +124,7 @@ void checkCrypto() {
    */
   const auto text = "Computer science is no more about computers than astronomy is about telescopes.";
   const auto passphrase5 = "viable weasel wage promote praise inflict jaguar tackle color unusual exclude direct";
-  ARK::Crypto::Utils::Message message;
+  Ark::Crypto::Utils::Message message;
   message.sign(text, passphrase5);
     Serial.print("\nSignature from Signed Message: ");
     Serial.println(BytesToHex(message.signature).c_str()); // the 'message.signature' is a byte-array. Use 'BytesToHex()' to view the output. Arduino requires a 'c_str()' to 'print'.

--- a/docs/tutorials/iot/examples/arduino/crypto/assets/esp8266.ino
+++ b/docs/tutorials/iot/examples/arduino/crypto/assets/esp8266.ino
@@ -35,7 +35,7 @@ void checkCrypto() {
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
    * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
-    ARK::Crypto::Configuration::Fee fee;
+    Ark::Crypto::Configuration::Fee fee;
     unsigned long typeZeroTransactionFee = fee.get(0);
     Serial.print("\n Type 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.

--- a/docs/tutorials/iot/examples/arduino/crypto/esp32/README.md
+++ b/docs/tutorials/iot/examples/arduino/crypto/esp32/README.md
@@ -44,7 +44,7 @@ void checkCrypto() {
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
    * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
-    ARK::Crypto::Configuration::Fee fee;
+    Ark::Crypto::Configuration::Fee fee;
     unsigned long typeZeroTransactionFee = fee.get(0);
     Serial.print("\n Type 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.
@@ -133,7 +133,7 @@ void checkCrypto() {
    */
   const auto text = "Computer science is no more about computers than astronomy is about telescopes.";
   const auto passphrase5 = "viable weasel wage promote praise inflict jaguar tackle color unusual exclude direct";
-  ARK::Crypto::Utils::Message message;
+  Ark::Crypto::Utils::Message message;
   message.sign(text, passphrase5);
     Serial.print("\nSignature from Signed Message: ");
     Serial.println(BytesToHex(message.signature).c_str()); // the 'message.signature' is a byte-array. Use 'BytesToHex()' to view the output. Arduino requires a 'c_str()' to 'print'.

--- a/docs/tutorials/iot/examples/arduino/crypto/esp8266/README.md
+++ b/docs/tutorials/iot/examples/arduino/crypto/esp8266/README.md
@@ -44,7 +44,7 @@ void checkCrypto() {
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
    * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
-    ARK::Crypto::Configuration::Fee fee;
+    Ark::Crypto::Configuration::Fee fee;
     unsigned long typeZeroTransactionFee = fee.get(0);
     Serial.print("\n Type 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.

--- a/docs/tutorials/iot/reacting-to-data-on-the-blockchain.md
+++ b/docs/tutorials/iot/reacting-to-data-on-the-blockchain.md
@@ -104,7 +104,7 @@ We'll also define the pin of the LED we want to blink.
 Create the connection object we'll use to talk to the [ARK blockchain](/introduction/blockchain) via its [API](/api).
 
 ```cpp
-ARK::Client::Connection<ARK::Client::Api> connection(darkIp, darkPort);
+Ark::Client::Connection<Ark::Client::Api> connection(darkIp, darkPort);
 ```
 
 Also create a variable to store your [VendorField](/glossary/#smartbridge), this will be your board ID's hash and is what we'll be searching for on the blockchain later.
@@ -172,7 +172,7 @@ const char* yourSecretPassphrase = "yourSecretPassphrase";
 
 #define led 13
 
-ARK::Client::Connection<ARK::Client::Api> connection(darkIp, darkPort);
+Ark::Client::Connection<Ark::Client::Api> connection(darkIp, darkPort);
 
 char vendorField[Sha256::BLOCK_LEN + 1] = { '\0' };
 
@@ -219,7 +219,7 @@ void sendTX(char vfBuffer[Sha256::BLOCK_LEN + 1]) {
     const auto shaHash = Sha256::getHash(&bytArray[0], idByteLen);
     memmove(vfBuffer, BytesToHex(&shaHash.value[0], &shaHash.value[0] + shaHash.HASH_LEN).c_str(), Sha256::BLOCK_LEN);
 
-     Transaction transaction = ARK::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, vfBuffer, yourSecretPassphrase);
+     Transaction transaction = Ark::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, vfBuffer, yourSecretPassphrase);
     const auto txJson = transaction.toJson();
 
     char jsonBuffer[576] = { '\0' };
@@ -441,7 +441,7 @@ const char* yourSecretPassphrase = "yourSecretPassphrase";
 
 #define led 13
 
-ARK::Client::Connection<ARK::Client::Api> connection(darkIp, darkPort);
+Ark::Client::Connection<Ark::Client::Api> connection(darkIp, darkPort);
 
 char vendorField[Sha256::BLOCK_LEN + 1] = { '\0' };
 
@@ -455,7 +455,7 @@ void sendTX(char vfBuffer[Sha256::BLOCK_LEN + 1]) {
     const auto shaHash = Sha256::getHash(&bytArray[0], idByteLen);
     memmove(vfBuffer, BytesToHex(&shaHash.value[0], &shaHash.value[0] + shaHash.HASH_LEN).c_str(), Sha256::BLOCK_LEN);
 
-    Transaction transaction = ARK::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, vfBuffer, yourSecretPassphrase);
+    Transaction transaction = Ark::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, vfBuffer, yourSecretPassphrase);
     const auto txJson = transaction.toJson();
 
     char jsonBuffer[576] = { '\0' };

--- a/docs/tutorials/iot/storing-data-on-the-blockchain.md
+++ b/docs/tutorials/iot/storing-data-on-the-blockchain.md
@@ -246,14 +246,14 @@ Transaction txFromHash(char hashBuffer[64]) {
 'return' the line to build the transaction.
 
 ```cpp
-return ARK::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, hashBuffer, yourSecretPassphrase);
+return Ark::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, hashBuffer, yourSecretPassphrase);
 ```
 
 It should look like this when you're finished:
 
 ```cpp
 Transaction txFromHash(char hashBuffer[64]) {
-   return ARK::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, hashBuffer, yourSecretPassphrase);
+   return Ark::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, hashBuffer, yourSecretPassphrase);
 };
 ```
 
@@ -285,7 +285,7 @@ std::string jsonStr(jsonBuffer);
 This is where we will use ARK Cpp-Client to create an API connection using the 'darkIp' and 'darkPort' we declared earlier.
 
 ```cpp
-ARK::Client::Connection<ARK::Client::Api> connection(darkIp, darkPort);
+Ark::Client::Connection<Ark::Client::Api> connection(darkIp, darkPort);
 ```
 
 Next we send the transactions array to the ARK network!
@@ -315,7 +315,7 @@ void loop() {
     snprintf(&jsonBuffer[0], 576, "{\"transactions\":[%s]}", transaction.toJson().c_str());
     std::string jsonStr(jsonBuffer);
 
-    ARK::Client::Connection<ARK::Client::Api> connection(darkIp, darkPort);
+    Ark::Client::Connection<Ark::Client::Api> connection(darkIp, darkPort);
 
     std::string txSendResponse = connection.api.transactions.send(jsonStr);
         Serial.print("\ntxSendResponse: ");
@@ -359,7 +359,7 @@ void idHashToBuffer(char hashBuffer[64]) {
 }
 
 Transaction txFromHash(char hashBuffer[64]) {
-    return ARK::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, hashBuffer, yourSecretPassphrase);
+    return Ark::Crypto::Transactions::Builder::buildTransfer(recipientId, 1, hashBuffer, yourSecretPassphrase);
 }
 
 void setupWiFi() {
@@ -390,7 +390,7 @@ void loop() {
     snprintf(&jsonBuffer[0], 576, "{\"transactions\":[%s]}", transaction.toJson().c_str());
     std::string jsonStr(jsonBuffer);
 
-    ARK::Client::Connection<ARK::Client::Api> connection(darkIp, darkPort);
+    Ark::Client::Connection<Ark::Client::Api> connection(darkIp, darkPort);
 
     std::string txSendResponse = connection.api.transactions.send(jsonStr);
         Serial.print("\ntxSendResponse: ");


### PR DESCRIPTION
Current docs show the C++ SDKs' top-level namespace as `ARK` where it should be `Ark`.
Namespaces are case-sensitive, so this is incorrect.

This PR changes `ARK` to `Ark` only in relevant doc and code examples pertaining to the C++ SDK's.

## What kind of change does this PR introduce?

- [x] Documentation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [n/a] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [n/a] New/updated tests are included
