### PR TITLE
fix: plugin order instructions

### DIFF
--- a/docs/tutorials/core/how-to-write-custom-transactions.md
+++ b/docs/tutorials/core/how-to-write-custom-transactions.md
@@ -510,10 +510,13 @@ Updating the *plugins.js* which contains all the plugins parameters for our netw
 
 ### plugins.js
 
-**First**, let's add our plugin to `plugins.js`. You can simply add after all core plugins this line:
+**First**, let's add our plugin to `plugins.js`. Make sure to add your plug-in before `"@arkecosystem/core-state"` e.g.:
 
 ```js
+...
 "custom-transactions": {},
+"@arkecosystem/core-state": {},
+...
 ```
 
 Here *custom-transactions* is the alias we have chosen (plugin definition in `index.ts`). No parameter is needed so we leave the parameters as en empty object.


### PR DESCRIPTION
Custom transaction plug-in should be loaded before `core-state` package.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## What
Update GTI plug-in tutorial to mention the plug-in should be loaded before the `core-state` package for bootstrapping to work properly.
<!-- What changes are being made? -->

## Why
Loading GIT plug-ins after `core-state` will cause state generation to not work properly on node restart. In this case, `core-state` will try to bootstrap a custom transaction before the handlers are registered.
<!-- Why are these changes necessary? -->