### PR TITLE
docs(sdk): fix client name typo for python

### DIFF
--- a/docs/sdk/clients/usage.md
+++ b/docs/sdk/clients/usage.md
@@ -672,9 +672,9 @@ $connection = new Connection([
 ::: tab python
 
 ```python
-from client import ARKClient
+from client import ArkClient
 
-client = ARKClient('http://127.0.0.1:4003/api')
+client = ArkClient('http://127.0.0.1:4003/api')
 ```
 
 :::


### PR DESCRIPTION
There is no `ARKClient` class in recent ARK python-client. Correct name is `ArkClient`.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
